### PR TITLE
Initial Objective-C block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ alert.setMessageText("Hello world!")
 alert.runModal
 ```
 
-## Future
-
-- Using Ruby's procs to bridge to Objective-C blocks
-
 ## Credit
 
 ObjRuby is a fork of [GNUstep's RIGS](https://github.com/gnustep/libs-ruby), which according to it's author/maintainer [Laurent Julliard](https://github.com/ljulliar):

--- a/ext/obj_ext/RIGSBridgeSupportParser.h
+++ b/ext/obj_ext/RIGSBridgeSupportParser.h
@@ -34,9 +34,10 @@
   NSString *_functionName;
   NSMutableString *_objcTypes;
   NSInteger _formatStringIndex;
+  NSInteger _blockIndex;
   NSInteger _argIndex;
+  NSInteger _argDepth;
 }
-
 @end
 
 #endif

--- a/ext/obj_ext/RIGSCore.h
+++ b/ext/obj_ext/RIGSCore.h
@@ -63,9 +63,10 @@ VALUE rb_objc_get_ruby_value_from_string(char * classname);
 void rb_objc_register_float_from_objc(const char *name, double value);
 void rb_objc_register_integer_from_objc(const char *name, long long value);
 void rb_objc_register_struct_from_objc(const char *key, const char *name, const char *args[], int argCount);
-void rb_objc_register_method_arg_from_objc(const char *selector, int index, BOOL formatString);
+void rb_objc_register_format_string_from_objc(const char *selector, int index);
+void rb_objc_register_block_from_objc(const char *selector, int index, const char *objcTypes);
 void rb_objc_register_constant_from_objc(const char *name, const char *type);
-void rb_objc_register_function_from_objc(const char *name, const char *objcTypes, int formatStringIndex);
+void rb_objc_register_function_from_objc(const char *name, const char *objcTypes);
 
 VALUE rb_objc_require_framework_from_ruby(VALUE rb_self, VALUE rb_name);
 

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -1149,11 +1149,13 @@ rb_objc_send_with_selector(SEL sel, int rigs_argc, VALUE *rigs_argv, VALUE rb_se
     nbArgs = [signature numberOfArguments];
     nbArgsExtra = rigs_argc - (nbArgs-2);
 
-    hash = rb_objc_hash(sel_getName(sel));
-
     if (nbArgsExtra < 0) {
       rb_raise(rb_eArgError, "wrong number of arguments (%d for %d)",rigs_argc, nbArgs-2);
       return Qnil;
+    }
+
+    if (nbArgs > 2) {
+      hash = rb_objc_hash(sel_getName(sel));
     }
 
     if (nbArgsExtra > 0) {
@@ -1171,12 +1173,6 @@ rb_objc_send_with_selector(SEL sel, int rigs_argc, VALUE *rigs_argv, VALUE rb_se
       signature = rb_objc_signature_with_format_string(signature, formatString, nbArgsExtra);
       nbArgs = [signature numberOfArguments];
     }
-    
-    NSDebugLog(@"Number of arguments = %d on %@", nbArgs-2, NSStringFromSelector(sel));
-    for (i = 2; i < [signature numberOfArguments]; i++) {
-        NSDebugLog (@"%ld -> %s", i-2, [signature getArgumentTypeAtIndex: i]);
-    }
-    NSDebugLog (@"returning %s", [signature methodReturnType]);
     
     invocation = [NSInvocation invocationWithMethodSignature: signature];
 

--- a/spec/foundation/array_spec.rb
+++ b/spec/foundation/array_spec.rb
@@ -49,7 +49,7 @@ describe ObjRuby::NSArray do
       sum += x.to_i
     end
 
-    expect(sum).to eq (1+2+3+4+5)
+    expect(sum).to eq(1 + 2 + 3 + 4 + 5)
   end
 
   it "can use a block return method" do

--- a/spec/foundation/array_spec.rb
+++ b/spec/foundation/array_spec.rb
@@ -40,4 +40,28 @@ describe ObjRuby::NSArray do
     expect(result.first).to eq 1
     expect(result.last).to eq 5
   end
+
+  it "can use a block method" do
+    array = described_class.arrayWithArray([1, 2, 3, 4, 5])
+
+    sum = 0
+    array.enumerateObjectsUsingBlock do |x|
+      sum += x.to_i
+    end
+
+    expect(sum).to eq (1+2+3+4+5)
+  end
+
+  it "can use a block return method" do
+    array1 = described_class.arrayWithArray([1, 2, 3, 4, 5])
+    array2 = described_class.arrayWithArray([1, 2, 3, 7, 9])
+
+    result = array1.differenceFromArray_withOptions_usingEquivalenceTest(array2, 0) do |x, y|
+      x == y
+    end
+
+    expect(result.hasChanges).to be true
+    expect(result.insertions.count).to be 2
+    expect(result.removals.count).to be 2
+  end
 end


### PR DESCRIPTION
Creates the ability to pass a Ruby block (or a Proc) to fill the role of an Objective-C block.  A test has been added to `spec/foundation/array.rb` with an example of its usage.

Note: Perhaps needs some cleanup yet inside of `RIGSCore.m` to refactor these additions and for `malloc` usage.