### PR TITLE
Adjust `objc_msgSend` for structs on Intel

### DIFF
--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -1301,13 +1301,11 @@ rb_objc_dispatch(id rcv, const char *method, NSMethodSignature *signature, int r
     // TODO: perhaps check [rcv methodForSelector:sel] for IMP
     nbArgsAdjust = 2;
     switch(*(signature.methodReturnType)) {
+#ifndef __aarch64__
     case _C_STRUCT_B:
       sym = objc_msgSend_stret;
       break;
-    case _C_FLT:
-    case _C_DBL:
-      sym = objc_msgSend_fpret;
-      break;
+#endif      
     default:
       sym = objc_msgSend;
       break;

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -915,6 +915,9 @@ rb_objc_convert_to_rb(void *data, int offset, const char *type, VALUE *rb_val_pt
                   }
 
                   Class retClass = [val classForCoder] ?: [val class];
+                  if (retClass != [val class] && strncmp(object_getClassName(val), "NSConcrete", 10) == 0) { 
+                    retClass = [val class];
+                  }
                   
                   NSDebugLog(@"Class of arg transmitted to Ruby = %@",NSStringFromClass(retClass));
 
@@ -1295,10 +1298,20 @@ rb_objc_dispatch(id rcv, const char *method, NSMethodSignature *signature, int r
   ffi_cif closureCif;
 
   if (rcv != nil) {
-    // TODO: check signature.methodReturnType for objc_msgSend_fpret/stret
     // TODO: perhaps check [rcv methodForSelector:sel] for IMP
     nbArgsAdjust = 2;
-    sym = objc_msgSend;
+    switch(*(signature.methodReturnType)) {
+    case _C_STRUCT_B:
+      sym = objc_msgSend_stret;
+      break;
+    case _C_FLT:
+    case _C_DBL:
+      sym = objc_msgSend_fpret;
+      break;
+    default:
+      sym = objc_msgSend;
+      break;
+    }
   }
   else {
     nbArgsAdjust = 0;

--- a/spec/app_kit/ns_alert_spec.rb
+++ b/spec/app_kit/ns_alert_spec.rb
@@ -3,9 +3,9 @@ require "obj_ruby/app_kit"
 
 describe ObjRuby::NSAlert do
   it "can create an instance" do
-    array = described_class.new
+    alert = described_class.new
 
-    expect(array).not_to be_nil
-    expect(array).to be_a described_class
+    expect(alert).not_to be_nil
+    expect(alert).to be_a described_class
   end
 end

--- a/spec/app_kit/ns_text_view_spec.rb
+++ b/spec/app_kit/ns_text_view_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+require "obj_ruby/app_kit"
+
+describe ObjRuby::NSTextView do
+  it "can create an instance" do
+    label = described_class.new
+
+    expect(label).not_to be_nil
+    expect(label).to be_a described_class
+  end
+
+  it "can call a method that returns a struct" do
+    label = described_class.new
+
+    text = ObjRuby::NSAttributedString.alloc.initWithString("Hello")
+    label.textStorage.setAttributedString(text)
+
+    label.layoutManager.ensureLayoutForTextContainer(label.textContainer)
+    rect = label.layoutManager.usedRectForTextContainer(label.textContainer)
+
+    expect(rect).not_to be_nil
+    expect(rect).to be_a ObjRuby::NSRect
+  end
+end


### PR DESCRIPTION
While there are some ABI differences between Intel and ARM on when exactly to use `objc_msgSend_stret` and `objc_msgSend_fpret` but it brings us a bit closer to reality.

Additionally, we need to modify our need to always expose clases by their public name, as some classes like `NSAttributedString` have `NSConcrete` versions that are returned in order to implement certain methods. We see this in `NSAttributedString#initWithString` For now, we check the internal class for `NSConcrete*` and allow that to go through.