### PR TITLE
Add ability to alias methods and custom BridgeSupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ earlier_date = date.earlierDate(other_date)
 
 Note you are allowed to mix some Ruby and Objective-C types. The following Ruby types will automatically bridge to these Objective-C types:
 
-| Ruby          | Objective-C   |
-| ------------- | ------------- |
-| String        | NSString      |
-| Array         | NSArray       |
-| Hash          | NSDictionary  |
-| Time          | NSDate        |
-| Numeric       | NSNumber      |
-| Nil           | NSNull        |
+| Ruby          | Objective-C            |
+| ------------- | ---------------------- |
+| String        | NSString               |
+| Array         | NS{Mutable}Array       |
+| Hash          | NS{Mutable}Dictionary  |
+| Time          | NSDate                 |
+| Numeric       | NSNumber               |
 
 ``` ruby
 require "obj_ruby"

--- a/ext/obj_ext/RIGSCore.h
+++ b/ext/obj_ext/RIGSCore.h
@@ -44,6 +44,8 @@ void rb_objc_register_constant_from_objc(const char *name, const char *type);
 void rb_objc_register_function_from_objc(const char *name, const char *objcTypes);
 void rb_objc_register_protocol_from_objc(const char *protocolName);
 
+BOOL rb_objc_register_framework_from_objc(char *framework, const char *root);
+
 VALUE rb_objc_import(VALUE rb_self, VALUE rb_name);
 VALUE rb_objc_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class);
 VALUE rb_objc_send(int rigs_argc, VALUE *rigs_argv, VALUE rb_self);

--- a/ext/obj_ext/RIGSNSArray.h
+++ b/ext/obj_ext/RIGSNSArray.h
@@ -26,6 +26,7 @@
 #include <ruby.h>
 #include <objc/runtime.h>
 
+VALUE rb_objc_array_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val);
 VALUE rb_objc_array_to_a(VALUE rb_self);
 VALUE rb_objc_array_to_rb(NSArray *val);
 NSArray* rb_objc_array_from_rb(VALUE rb_val);

--- a/ext/obj_ext/RIGSNSDictionary.h
+++ b/ext/obj_ext/RIGSNSDictionary.h
@@ -26,6 +26,7 @@
 #include <ruby.h>
 #include <objc/runtime.h>
 
+VALUE rb_objc_dictionary_store(VALUE rb_self, VALUE rb_key, VALUE rb_val);
 VALUE rb_objc_dictionary_to_h(VALUE rb_self);
 VALUE rb_objc_dictionary_to_rb(NSDictionary *val);
 NSDictionary* rb_objc_dictionary_from_rb(VALUE rb_val);

--- a/ext/obj_ext/RIGSNSString.m
+++ b/ext/obj_ext/RIGSNSString.m
@@ -42,5 +42,7 @@ rb_objc_string_to_rb(NSString *val)
 NSString*
 rb_objc_string_from_rb(VALUE rb_val)
 {
+  Check_Type(rb_val, T_STRING);
+  
   return [NSString stringWithUTF8String:rb_string_value_cstr(&rb_val)];
 }

--- a/ext/obj_ext/RIGSUtilities.h
+++ b/ext/obj_ext/RIGSUtilities.h
@@ -55,6 +55,7 @@ struct rb_objc_block {
 
 SEL rb_objc_method_to_sel(const char* name, int argc);
 char *rb_objc_sel_to_method(SEL sel);
+char *rb_objc_sel_to_alias(SEL sel);
 
 unsigned long rb_objc_hash(const char* value);
 const char *objc_skip_type_qualifiers (const char *type);

--- a/lib/obj_ruby/support.rb
+++ b/lib/obj_ruby/support.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# obj_ruby.rb - Main file to require to start using ObjRuby
+# support.rb - Declare ObjRuby Support
 #
 # Written by: Ryan Krug <keegnotrub@icloud.com>
-# Date: May 2023
+# Date: June 2025
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Library General Public
@@ -19,6 +19,6 @@
 # License along with this library; if not, write to the Free
 # Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 
-require "obj_ruby/version"
-require "obj_ruby/support"
-require "obj_ext"
+module ObjRuby
+  SUPPORT = File.expand_path("../../support", __dir__)
+end

--- a/obj_ruby.gemspec
+++ b/obj_ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.metadata = { "rubygems_mfa_required" => "true" }
 
-  s.files = `git ls-files -- {ext,lib}/*`.split("\n")
+  s.files = `git ls-files -- {ext,lib,support}/*`.split("\n")
   s.require_paths = ["lib"]
   s.extensions = ["ext/obj_ext/extconf.rb"]
 

--- a/spec/obj_ruby/ns_array_spec.rb
+++ b/spec/obj_ruby/ns_array_spec.rb
@@ -10,7 +10,19 @@ RSpec.describe ObjRuby::NSArray do
     expect(array).to be_a described_class
   end
 
-  it "can call instance methods" do
+  it "can receive a Ruby array" do
+    array = described_class.arrayWithArray([1, 2, 3, 4, 5])
+
+    expect(array.count).to eq 5
+    expect(array.indexOfObject(1)).to eq 0
+    expect(array.indexOfObject(2)).to eq 1
+    expect(array.indexOfObject(3)).to eq 2
+    expect(array.indexOfObject(4)).to eq 3
+    expect(array.indexOfObject(5)).to eq 4
+    expect(array.indexOfObject_inRange(1, ObjRuby::NSRange.new(1, array.count - 1))).to eq ObjRuby::NSNotFound
+  end
+
+  it "can receive a variable argument list" do
     array = described_class.arrayWithObjects("here", "there", "everywhere", nil)
 
     expect(array.count).to eq 3
@@ -24,31 +36,28 @@ RSpec.describe ObjRuby::NSArray do
     expect(array.indexOfObject("not here")).to eq ObjRuby::NSNotFound
   end
 
-  it "can receive a Ruby array" do
-    array = described_class.arrayWithArray([1, nil, 3, 4, 5])
-
-    expect(array.count).to eq 5
-    expect(array.indexOfObject(1)).to eq 0
-    expect(array.indexOfObject(ObjRuby::NSNull.null)).to eq 1
-    expect(array.indexOfObject_inRange(1, ObjRuby::NSRange.new(1, array.count - 1))).to eq ObjRuby::NSNotFound
-  end
-
-  it "can receive a variable argument list" do
+  it "is equal when what it received was equal" do
     array = described_class.arrayWithArray([1, 2, 3, 4, 5])
-    manual_array = described_class.arrayWithArray([1, 2, 3, 4, 5])
+    manual_array = described_class.arrayWithObjects(1, 2, 3, 4, 5, nil)
 
     expect(array.isEqualToArray(manual_array)).to be true
   end
 
+  it "can be indexed with a subscript" do
+    array = described_class.arrayWithArray([1, 2, "hi", 4, 5])
+
+    expect(array[1]).to eq(2)
+    expect(array[2]).to eq("hi")
+  end
+
   it "can be transformed into a Ruby array" do
-    array = described_class.arrayWithArray([1, nil, 3, 4, 5])
+    array = described_class.arrayWithArray([1, 2, 3, 4, 5])
 
     result = array.to_a
 
     expect(result).to be_a Array
     expect(result.size).to eq 5
     expect(result[0]).to eq 1
-    expect(result[1]).to be_nil
   end
 
   it "can use a block method" do

--- a/spec/obj_ruby/ns_dictionary_spec.rb
+++ b/spec/obj_ruby/ns_dictionary_spec.rb
@@ -10,36 +10,45 @@ RSpec.describe ObjRuby::NSDictionary do
     expect(dict).to be_a described_class
   end
 
-  it "can call instance methods" do
-    dict = described_class.dictionaryWithObject_forKey("value", "key")
-
-    expect(dict.objectForKey(:key)).to eq "value"
-    expect(dict.objectForKey(:not_key)).to be_nil
-  end
-
   it "can receive a Ruby hash" do
-    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: nil)
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
 
     expect(dict.count).to eq 2
     expect(dict.objectForKey(:key1)).to eq "value1"
-    expect(dict.objectForKey(:key2)).to eq ObjRuby::NSNull.null
+    expect(dict.objectForKey(:key2)).to eq "value2"
     expect(dict.objectForKey(:not_key)).to be_nil
   end
 
   it "can receive a variable argument list" do
+    dict = described_class.dictionaryWithObjectsAndKeys("value1", :key1, "value2", :key2, nil)
+
+    expect(dict.count).to eq 2
+    expect(dict.objectForKey(:key1)).to eq "value1"
+    expect(dict.objectForKey(:key2)).to eq "value2"
+    expect(dict.objectForKey(:not_key)).to be_nil
+  end
+
+  it "is equal when what it received was equal" do
     dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
     manual_dict = described_class.dictionaryWithObjectsAndKeys("value1", :key1, "value2", :key2, nil)
 
     expect(dict.isEqualToDictionary(manual_dict)).to be true
   end
 
+  it "can be keyed with a subscript" do
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
+
+    expect(dict[:key1]).to eq("value1")
+    expect(dict[:key2]).to eq("value2")
+  end
+
   it "can be transformed into a Ruby hash" do
-    dict = described_class.dictionaryWithDictionary(key1: "value", key2: nil)
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
 
     hash = dict.to_h
 
     expect(hash).to be_a Hash
-    expect(hash["key1"]).to eq "value"
-    expect(hash["key2"]).to be_nil
+    expect(hash["key1"]).to eq "value1"
+    expect(hash["key2"]).to eq "value2"
   end
 end

--- a/spec/obj_ruby/ns_layout_manager_spec.rb
+++ b/spec/obj_ruby/ns_layout_manager_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ObjRuby::NSLayoutManager do
+  it "can create an instance" do
+    label = described_class.new
+
+    expect(label).not_to be_nil
+    expect(label).to be_a described_class
+  end
+
+  it "can call a method that returns a struct" do
+    layout = described_class.new
+
+    label = ObjRuby::NSTextView.new
+    label.textStorage.setAttributedString(
+      ObjRuby::NSAttributedString.alloc.initWithString("Hello")
+    )
+
+    container = label.textContainer
+    layout.addTextContainer(container)
+    layout.ensureLayoutForTextContainer(container)
+
+    rect = layout.usedRectForTextContainer(container)
+
+    expect(rect).not_to be_nil
+    expect(rect).to be_a ObjRuby::NSRect
+  end
+end

--- a/spec/obj_ruby/ns_mutable_array_spec.rb
+++ b/spec/obj_ruby/ns_mutable_array_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ObjRuby::NSMutableArray do
+  it "can create an instance" do
+    array = described_class.new
+
+    expect(array).not_to be_nil
+    expect(array).to be_a described_class
+  end
+
+  it "can add objects" do
+    array = described_class.new
+
+    expect do
+      array << "one"
+      array << "two"
+      array << "three"
+    end.to change(array, :count).by(3)
+
+    expect(array[0]).to eq("one")
+    expect(array[1]).to eq("two")
+    expect(array[2]).to eq("three")
+  end
+
+  it "can add objects by indexed subscript" do
+    array = described_class.new
+
+    expect do
+      array[0] = "one"
+      array[1] = "two"
+      array[2] = "three"
+    end.to change(array, :count).by(3)
+
+    expect(array[0]).to eq("one")
+    expect(array[1]).to eq("two")
+    expect(array[2]).to eq("three")
+  end
+
+  it "can replace objects" do
+    array = described_class.arrayWithArray([1, 2, 3])
+
+    expect do
+      array.replaceObjectAtIndex_withObject(0, "one")
+      array.replaceObjectAtIndex_withObject(1, "two")
+      array.replaceObjectAtIndex_withObject(2, "three")
+    end.not_to change(array, :count)
+
+    expect(array[0]).to eq("one")
+    expect(array[1]).to eq("two")
+    expect(array[2]).to eq("three")
+  end
+
+  it "can replace objects by indexed subscript" do
+    array = described_class.arrayWithArray([1, 2, 3])
+
+    expect do
+      array[0] = "one"
+      array[1] = "two"
+      array[2] = "three"
+    end.not_to change(array, :count)
+
+    expect(array[0]).to eq("one")
+    expect(array[1]).to eq("two")
+    expect(array[2]).to eq("three")
+  end
+
+  it "can remove objects" do
+    array = described_class.arrayWithArray([1, 2, 3])
+
+    expect do
+      array.removeObject(2)
+    end.to change(array, :count).by(-1)
+
+    expect(array[0]).to eq(1)
+    expect(array[1]).to eq(3)
+  end
+end

--- a/spec/obj_ruby/ns_mutable_data_spec.rb
+++ b/spec/obj_ruby/ns_mutable_data_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ObjRuby::NSMutableData do
+  it "can create an instance" do
+    data = described_class.new
+
+    expect(data).not_to be_nil
+    expect(data).to be_a described_class
+  end
+
+  it "can append data" do
+    data = described_class.new
+    hello = ObjRuby::NSString.stringWithString("hello")
+
+    expect do
+      data << hello.dataUsingEncoding(ObjRuby::NSUTF8StringEncoding)
+    end.to change(data, :length).by(hello.length)
+  end
+end

--- a/spec/obj_ruby/ns_mutable_dictionary_spec.rb
+++ b/spec/obj_ruby/ns_mutable_dictionary_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ObjRuby::NSMutableDictionary do
+  it "can create an instance" do
+    dict = described_class.new
+
+    expect(dict).not_to be_nil
+    expect(dict).to be_a described_class
+  end
+
+  it "can add entries" do
+    dict = described_class.new
+
+    expect do
+      dict.setObject_forKey(1, "one")
+      dict.setObject_forKey(2, "two")
+      dict.setObject_forKey(3, "three")
+    end.to change(dict, :count).by(3)
+
+    expect(dict["one"]).to eq(1)
+    expect(dict["two"]).to eq(2)
+    expect(dict["three"]).to eq(3)
+  end
+
+  it "can add entries by keyed subscript" do
+    dict = described_class.new
+
+    expect do
+      dict["one"] = 1
+      dict["two"] = 2
+      dict["three"] = 3
+    end.to change(dict, :count).by(3)
+
+    expect(dict["one"]).to eq(1)
+    expect(dict["two"]).to eq(2)
+    expect(dict["three"]).to eq(3)
+  end
+
+  it "can replace entries" do
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
+
+    expect do
+      dict.setObject_forKey("value1!", :key1)
+      dict.setObject_forKey("value2!", :key2)
+    end.not_to change(dict, :count)
+
+    expect(dict[:key1]).to eq("value1!")
+    expect(dict[:key2]).to eq("value2!")
+  end
+
+  it "can replace entries by keyed subscript" do
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
+
+    expect do
+      dict[:key1] = "value1!"
+      dict[:key2] = "value2!"
+    end.not_to change(dict, :count)
+
+    expect(dict[:key1]).to eq("value1!")
+    expect(dict[:key2]).to eq("value2!")
+  end
+
+  it "can remove entries" do
+    dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
+
+    expect do
+      dict.removeObjectForKey(:key1)
+    end.to change(dict, :count).by(-1)
+
+    expect(dict[:key1]).to be_nil
+    expect(dict[:key2]).to eq("value2")
+  end
+end

--- a/spec/obj_ruby/ns_mutable_string_spec.rb
+++ b/spec/obj_ruby/ns_mutable_string_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ObjRuby::NSMutableString do
+  it "can create an instance" do
+    string = described_class.new
+
+    expect(string).not_to be_nil
+    expect(string).to be_a described_class
+  end
+
+  it "can append a string" do
+    data = described_class.new
+    hello = ObjRuby::NSString.stringWithString("hello")
+
+    expect do
+      data << hello
+    end.to change(data, :length).by(hello.length)
+  end
+end

--- a/spec/obj_ruby/ns_null_spec.rb
+++ b/spec/obj_ruby/ns_null_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe ObjRuby::NSNull do
     expect(null).to be_a described_class
     expect(null).not_to be_nil
   end
+
+  it "is equal to the singleton for any instance" do
+    expect(described_class.new).to eq(described_class.null)
+  end
 end

--- a/spec/obj_ruby/ns_number_spec.rb
+++ b/spec/obj_ruby/ns_number_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe ObjRuby::NSNumber do
     expect(number.doubleValue).to eq 3.0
   end
 
+  it "can be compared to a Ruby numeric or bool" do
+    number = described_class.numberWithInt(3)
+
+    expect(number.isEqualToNumber(3)).to be true
+    expect(number.isEqualToNumber(4)).to be false
+    expect(number.isEqualToNumber(3.1)).to be false
+    expect(number.isEqualToNumber(false)).to be false
+    expect(number.isEqualToNumber(true)).to be false
+  end
+
   it "can be transformed into a Ruby integer" do
     number = described_class.numberWithInt(3)
 

--- a/spec/obj_ruby/ns_object_spec.rb
+++ b/spec/obj_ruby/ns_object_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe ObjRuby::NSObject do
       expect(obj.respondsToSelector("myObjcMethod")).to be(true)
     end
 
+    it "can call subclass methods that raise" do
+      obj = TestMyObject.new
+
+      expect do
+        obj.performSelector(:myDangerousObjcMethod)
+      end.to raise_error RuntimeError, "expected myDangerousObjcMethod message"
+    end
+
     it "can call subclass methods with one arg from the Objective-C runtime" do
       obj = TestMyObject.new
 

--- a/spec/obj_ruby/ns_string_spec.rb
+++ b/spec/obj_ruby/ns_string_spec.rb
@@ -10,7 +10,14 @@ RSpec.describe ObjRuby::NSString do
     expect(string).to be_a described_class
   end
 
-  it "can call instance methods" do
+  it "can receive variable length arguments" do
+    string = described_class.stringWithFormat("one %d three %@ %d", 2, "four", 5)
+
+    expect(string.length).to eq 18
+    expect(string).to eq "one 2 three four 5"
+  end
+
+  it "can reeceive a C string" do
     string = described_class.stringWithCString("hello")
 
     expect(string.length).to eq 5
@@ -32,11 +39,5 @@ RSpec.describe ObjRuby::NSString do
     expect(result).to be_a String
     expect(result.size).to eq 5
     expect(result).to eq "hello"
-  end
-
-  it "can receive variable length arguments" do
-    string = described_class.stringWithFormat("one %d three %@ %d", 2, "four", 5)
-
-    expect(string).to eq "one 2 three four 5"
   end
 end

--- a/spec/obj_ruby/ns_view_spec.rb
+++ b/spec/obj_ruby/ns_view_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe ObjRuby::NSView do
     expect(view).to be_a described_class
   end
 
+  it "can call methods that are aliased" do
+    view = described_class.new
+
+    view.hidden = true
+    expect(view.hidden?).to be(true)
+  end
+
   it "can call a method that returns a struct" do
     view = described_class.new
 

--- a/spec/obj_ruby/nsxml_parser_spec.rb
+++ b/spec/obj_ruby/nsxml_parser_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ObjRuby::NSXMLParser do
     parser = described_class.alloc.initWithData(data)
 
     delegate = TestXMLParserDelegate.new
-    parser.setDelegate(delegate)
+    parser.delegate = delegate
 
     result = parser.parse
 

--- a/spec/obj_ruby/runtime_error_spec.rb
+++ b/spec/obj_ruby/runtime_error_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ObjRuby::RuntimeError do
+  it "is raised when we have an uncaught Objective-C exception" do
+    expect do
+      obj = ObjRuby::NSObject.new
+      obj.performSelector(:notASelector)
+    end.to raise_error(described_class)
+  end
+end

--- a/spec/obj_ruby_spec.rb
+++ b/spec/obj_ruby_spec.rb
@@ -4,15 +4,15 @@ require "spec_helper"
 
 RSpec.describe ObjRuby do
   describe ".import" do
+    it "returns true for frameworks not yet loaded" do
+      expect(described_class.import("WebKit")).to be true
+    end
+
     it "returns false for already loaded frameworks" do
       # spec_helper loads these
       expect(described_class.import("Foundation")).to be false
       expect(described_class.import("CoreData")).to be false
       expect(described_class.import("AppKit")).to be false
-    end
-
-    it "returns true for frameworks not yet loaded" do
-      expect(described_class.import("WebKit")).to be true
     end
 
     it "raises an error for unknown frameworks" do
@@ -21,7 +21,17 @@ RSpec.describe ObjRuby do
       end.to raise_error(LoadError)
     end
 
-    it "defines Foundation Objective-C constants" do
+    it "defines unbridged Foundation Objective-C classes" do
+      described_class.import("Foundation")
+
+      expect(described_class.const_get(:NSNull)).to be_a Class
+      expect(described_class.const_get(:NSMutableDictionary)).to be_a Class
+      expect(described_class.const_get(:NSCountedSet)).to be_a Class
+    end
+
+    it "defines bridged Foundation Objective-C constants" do
+      described_class.import("Foundation")
+
       expect(described_class.const_get(:NSNotFound)).to eq (2**63) - 1
       expect(described_class.const_get(:NSOrderedSame)).to eq 0
       expect(described_class.const_get(:NSASCIIStringEncoding)).to eq 1
@@ -29,11 +39,15 @@ RSpec.describe ObjRuby do
       expect(described_class.const_get(:NSZombieEnabled)).to be false
     end
 
-    it "defines CoreData Objective-C constants" do
+    it "defines bridged CoreData Objective-C constants" do
+      described_class.import("CoreData")
+
       expect(described_class.const_get(:NSAffectedObjectsErrorKey)).to eq "NSAffectedObjectsErrorKey"
     end
 
-    it "defines AppKit Objective-C constants" do
+    it "defines bridged AppKit Objective-C constants" do
+      described_class.import("AppKit")
+
       expect(described_class.const_get(:NSOKButton)).to eq 1
       expect(described_class.const_get(:NSCancelButton)).to eq 0
     end

--- a/spec/support/test_my_object.rb
+++ b/spec/support/test_my_object.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class TestMyObject < ObjRuby::NSObject
+  include ::Kernel
+
   def myObjcMethod
     "expected myObjcMethod return"
+  end
+
+  def myDangerousObjcMethod
+    raise "expected myDangerousObjcMethod message"
   end
 
   def myObjcMethodWithArg(arg)

--- a/support/Frameworks/Foundation.framework/Resources/BridgeSupport/Foundation.arm64e.bridgesupport
+++ b/support/Frameworks/Foundation.framework/Resources/BridgeSupport/Foundation.arm64e.bridgesupport
@@ -1,0 +1,7 @@
+<?xml version='1.0'?>
+<!DOCTYPE signatures SYSTEM "file://localhost/System/Library/DTDs/BridgeSupport.dtd">
+<signatures version='1.0'>
+  <class name='NSNull' />
+  <class name='NSMutableDictionary' />
+  <class name='NSCountedSet' />
+</signatures>

--- a/support/Frameworks/Foundation.framework/Resources/BridgeSupport/Foundation.bridgesupport
+++ b/support/Frameworks/Foundation.framework/Resources/BridgeSupport/Foundation.bridgesupport
@@ -1,0 +1,7 @@
+<?xml version='1.0'?>
+<!DOCTYPE signatures SYSTEM "file://localhost/System/Library/DTDs/BridgeSupport.dtd">
+<signatures version='1.0'>
+  <class name='NSNull' />
+  <class name='NSMutableDictionary' />
+  <class name='NSCountedSet' />
+</signatures>


### PR DESCRIPTION
Auto alias these methods:

```
- setFoo: -> foo=
- isFoo -> foo?
- objectAtIndexedSubscript: -> []
- objectForKeyedSubscript: -> []
```

Also adds custom alias for NSMutable{Array,Dictionary}

```
- setObject:atIndexedSubscript: -> []=
- setObject:forKeyedSubscript: -> []=
```

And for some for appending:

```
- NSMutableString appendString: -> <<
- NSMutableData appendData -> <<
- NSMutableArray addObject: -> <<
```

In doing this I realized:

- We were missing some important classes that were not in Apple's BridgeSupport files, so this adds a custom BridgeSupport load to get them.
- We were setting __way__ to many methods from Objective-C, so we now trim out odd-ball methods that have underscores in them as they'd never survive our translation to and from Ruby methods.
- It was a mistake to partially bridge NSNull to nil. Ruby has but one concept for nil, so we should just make nil == nil in Obj-C, and if you need NSNull, use ObjRuby::NSNull directly.
- Our global exception handler will stop working the minute you do something in AppKit, as I suspect AppKit has its own global exception handler that overwrites ours. For now lets just catch and raise in methods that call our dispatch function as that's the hot path.
- rb_objc_register_class_from_objc isn't called directly from Ruby so it doesn't need an autorelease block.

Fixes #13 and #10