### PR TITLE
Support NSSet and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ require "obj_ruby/foundation"
 date = ObjRuby::NSDate.dateWithTimeIntervalSince1970(42424242)
 other_date = date.addTimeInterval(1000)
 earlier_date = date.earlierDate(other_date)
+
+puts earlier_date.isEqualToDate(date) # true
 ```
 
 Note you are allowed to mix some Ruby and Objective-C types. The following Ruby types will automatically bridge to these Objective-C types:
@@ -41,17 +43,30 @@ Note you are allowed to mix some Ruby and Objective-C types. The following Ruby 
 | Ruby          | Objective-C            |
 | ------------- | ---------------------- |
 | String        | NSString               |
+| Numeric       | Immediate or NSNumber  |
+| Time          | NSDate                 |
 | Array         | NS{Mutable}Array       |
 | Hash          | NS{Mutable}Dictionary  |
-| Time          | NSDate                 |
-| Numeric       | NSNumber               |
+| Set           | NS{Mutable}Set         |
 
 ``` ruby
 require "obj_ruby"
 require "obj_ruby/foundation"
 
-dict = ObjRuby::NSMutableDictionary.new
-dict.setObject_forKey(Time.now, "Hello!")
+# bridging manually
+ary1 = ObjRuby::NSMutableArray.arrayWithObjects(
+  ObjRuby::NSNumber.numberWithInt(1),
+  ObjRuby::NSNumber.numberWithInt(2),
+  ObjRuby::NSNumber.numberWithInt(3),
+  nil
+)
+ary1.addObject(ObjRuby::NSNumber.numberWithInt(4))
+
+# bridging with coercion helpers
+ary2 = ObjRuby::NSMutableArray([1,2,3])
+ary2 << 4
+
+puts ary1 == ary2 # true
 ```
 
 Other frameworks, like the [AppKit framework](https://developer.apple.com/documentation/appkit?language=objc) for graphical user interfaces, are also supported.
@@ -61,11 +76,11 @@ require "obj_ruby"
 require "obj_ruby/app_kit"
 
 app = ObjRuby::NSApplication.sharedApplication
-app.setActivationPolicy ObjRuby::NSApplicationActivationPolicyRegular
+app.activationPolicy = ObjRuby::NSApplicationActivationPolicyRegular
 app.activateIgnoringOtherApps(true)
 
 alert = ObjRuby::NSAlert.new
-alert.setMessageText("Hello world!")
+alert.messageText = "Hello world!"
 alert.runModal
 ```
 

--- a/ext/obj_ext/RIGSCore.h
+++ b/ext/obj_ext/RIGSCore.h
@@ -29,7 +29,9 @@
 #include <ffi/ffi.h>
 
 BOOL rb_objc_convert_to_objc(VALUE rb_val, void **data, size_t offset, const char *type);
-BOOL rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val_ptr, BOOL autoconvert);
+BOOL rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val_ptr);
+
+BOOL rb_objc_register_framework_from_objc(char *framework, const char *root);
 
 VALUE rb_objc_register_class_from_objc(Class objc_class);
 VALUE rb_objc_register_class_from_rb(VALUE rb_class);
@@ -44,12 +46,11 @@ void rb_objc_register_constant_from_objc(const char *name, const char *type);
 void rb_objc_register_function_from_objc(const char *name, const char *objcTypes);
 void rb_objc_register_protocol_from_objc(const char *selector, const char *objcTypes);
 
-BOOL rb_objc_register_framework_from_objc(char *framework, const char *root);
-
 VALUE rb_objc_import(VALUE rb_self, VALUE rb_name);
 VALUE rb_objc_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class);
 VALUE rb_objc_send(int rigs_argc, VALUE *rigs_argv, VALUE rb_self);
 VALUE rb_objc_invoke(int rigs_argc, VALUE *rigs_argv, VALUE rb_self);
+VALUE rb_objc_false(VALUE rb_self);
 
 void rb_objc_raise_exception(NSException *exception);
 

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -29,6 +29,7 @@
 #import "RIGSNSObject.h"
 #import "RIGSNSDictionary.h"
 #import "RIGSNSArray.h"
+#import "RIGSNSSet.h"
 #import "RIGSNSString.h"
 #import "RIGSNSNumber.h"
 #import "RIGSNSDate.h"
@@ -71,6 +72,8 @@ static VALUE rb_eRigsRuntimeError = Qnil;
 // Rigs Ruby Ptr class
 static VALUE rb_cRigsPtr = Qnil;
 
+static VALUE rb_cSet = Qnil;
+
 void
 rb_objc_release(id objc_object) 
 {
@@ -101,7 +104,7 @@ rb_objc_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class)
     Class objc_class;
 
     // get the class from the objc_class class variable now
-    objc_class = (Class) NUM2LL(rb_iv_get(rb_class, "@objc_class"));
+    objc_class = (Class)NUM2LL(rb_iv_get(rb_class, "@objc_class"));
 
     // This object is not released on purpose. The Ruby garbage collector
     // will take care of deallocating it by calling rb_objc_release()
@@ -322,19 +325,22 @@ rb_objc_convert_to_objc(VALUE rb_thing, void **data, size_t offset, const char *
         {
         case T_DATA:
           if (rb_obj_is_kind_of(rb_val, rb_cTime) == Qtrue) {
-            *(NSDate**)where = rb_objc_date_from_rb(rb_val);
+            *(id*)where = rb_objc_date_from_rb(rb_val);
+          }
+          else if (rb_iv_get(CLASS_OF(rb_val), "@objc_class") != Qnil) {
+            Data_Get_Struct(rb_val, void, *(id*)where);
           }
           else {
-            Data_Get_Struct(rb_val, void, *(id*)where);
+            ret = NO;
           }
           break;
 
         case T_SYMBOL:
-          *(NSString**)where = rb_objc_string_from_rb(rb_sym_to_s(rb_val));
+          *(id*)where = rb_objc_string_from_rb(rb_val, Qtrue);
           break;
 
         case T_STRING:
-          *(NSString**)where = rb_objc_string_from_rb(rb_val);
+          *(id*)where = rb_objc_string_from_rb(rb_val, RB_OBJ_FROZEN(rb_val));
           break;
 
         case T_CLASS:
@@ -342,19 +348,21 @@ rb_objc_convert_to_objc(VALUE rb_thing, void **data, size_t offset, const char *
           break;
 
         case T_OBJECT:
-          /* Ruby sends a Ruby class or a ruby object. Automatically register
-             an ObjC proxy class. It is very likely that we'll need it in the future
-             (e.g. typical for setDelegate method call) */
-          Data_Get_Struct(rb_val, void, *(id*)where);
-          NSDebugLog(@"Wrapping Ruby Object of type: 0x%02x (ObjC object at %p)", TYPE(rb_val), where);
+          if (rb_obj_is_kind_of(rb_val, rb_cSet) == Qtrue) {
+            *(id*)where = rb_objc_set_from_rb(rb_val, RB_OBJ_FROZEN(rb_val));
+          }
+          else {
+            // TODO: check coercion (ie: rb_check_string_type)
+            ret = NO;
+          }
           break;
           
         case T_ARRAY:
-          *(NSArray**)where = rb_objc_array_from_rb(rb_val);
+          *(id*)where = rb_objc_array_from_rb(rb_val, RB_OBJ_FROZEN(rb_val));
           break;
                     
         case T_HASH:
-          *(NSDictionary**)where = rb_objc_dictionary_from_rb(rb_val);
+          *(id*)where = rb_objc_dictionary_from_rb(rb_val, RB_OBJ_FROZEN(rb_val));
           break;
 
         case T_FIXNUM:
@@ -362,7 +370,7 @@ rb_objc_convert_to_objc(VALUE rb_thing, void **data, size_t offset, const char *
         case T_FLOAT:
         case T_FALSE:
         case T_TRUE:
-          *(NSNumber**)where = rb_objc_number_from_rb(rb_val);
+          *(id*)where = rb_objc_number_from_rb(rb_val);
           break;
 
         default:
@@ -608,7 +616,7 @@ rb_objc_convert_to_objc(VALUE rb_thing, void **data, size_t offset, const char *
 }
 
 BOOL
-rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val_ptr, BOOL autoconvert)
+rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val_ptr)
 {
   BOOL ret = YES;
   VALUE rb_class;
@@ -659,16 +667,6 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
         id val = *(id*)where;
         if (val == nil) {
           rb_val = Qnil;                  
-        } else if ( autoconvert && [[val classForCoder] isSubclassOfClass:[NSString class]] ) {
-          rb_val = rb_objc_string_to_rb(val);
-        } else if ( autoconvert && [[val classForCoder] isSubclassOfClass:[NSNumber class]] ) {
-          rb_val = rb_objc_number_to_rb(val);
-        } else if ( autoconvert && [[val classForCoder] isSubclassOfClass:[NSArray class]] ) {
-          rb_val = rb_objc_array_to_rb(val);
-        } else if ( autoconvert && [[val classForCoder] isSubclassOfClass:[NSDictionary class]] ) {
-          rb_val = rb_objc_dictionary_to_rb(val);
-        } else if ( autoconvert && [[val classForCoder] isSubclassOfClass:[NSDate class]] ) {
-          rb_val = rb_objc_date_to_rb(val);
         } else if ( (rb_val = (VALUE) NSMapGet(knownObjects,(void *)val)) )  {
           NSDebugLog(@"ObjC object already wrapped in an existing Ruby value (%p)", (void*)rb_val);
         } else {
@@ -682,6 +680,8 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
 
           Class retClass = [val classForCoder];
           if (retClass != [val class] && strncmp(object_getClassName(val), "NSConcrete", 10) == 0) {
+            // [NSAttributedString alloc] returns NSConcreteAttributedString
+            // which is where initWithString is defined so we need it defined in Ruby
             retClass = [val class];
           }
 
@@ -767,15 +767,15 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
         break;
 
       case _C_SHT:
-        rb_val = INT2FIX((int) (*(short *) where));
+        rb_val = INT2FIX((long) (*(short *) where));
         break;
 
       case _C_USHT:
-        rb_val = INT2FIX((int) (*(unsigned short *) where));
+        rb_val = INT2FIX((long) (*(unsigned short *) where));
         break;
 
       case _C_INT:
-        rb_val = INT2FIX(*(int *)where);
+        rb_val = INT2FIX((long) (*(int *) where));
         break;
 
       case _C_UINT:
@@ -783,7 +783,7 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
         break;
 
       case _C_LNG:
-        rb_val = LONG2NUM(*(long*)where);
+        rb_val = INT2FIX(*(long*)where);
         break;
 
       case _C_ULNG:
@@ -843,7 +843,7 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
           // We are attacking a new embedded structure in a structure
             
           
-          if ( rb_objc_convert_to_rb(where, 0, type, &rb_val, autoconvert) == NO) {     
+          if ( rb_objc_convert_to_rb(where, 0, type, &rb_val) == NO) {
             // if something went wrong in the conversion just return Qnil
             rb_val = Qnil;
             ret = NO;
@@ -1024,7 +1024,7 @@ rb_objc_proxy_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
 
     for (i=2;i<cif->nargs;i++) {
       type = [signature getArgumentTypeAtIndex:i];
-      rb_objc_convert_to_rb(args[i], 0, type, &rubyArgs[i-2], NO);
+      rb_objc_convert_to_rb(args[i], 0, type, &rubyArgs[i-2]);
     }
 
     rubyRetVal = rb_funcallv(rubyObject, rb_intern(rubyMethodName), cif->nargs - 2, rubyArgs);
@@ -1038,7 +1038,7 @@ rb_objc_proxy_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
       // when calling code is Ruby -> Objective-C -> Ruby
       // Example: rb_obj.performSelector(:proxyHandlerMethod)
       if (rb_objc_convert_to_objc(rubyRetVal, &data, 0, type)) {
-        rb_objc_convert_to_rb(data, 0, type, &rubyRetVal, NO);
+        rb_objc_convert_to_rb(data, 0, type, &rubyRetVal);
       }
 
       *(ffi_arg*)ret = *(ffi_arg*)data;
@@ -1072,7 +1072,7 @@ rb_objc_block_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
 
     for (i=1;i<nbArgs;i++) {
       type = [signature getArgumentTypeAtIndex:i];
-      rb_objc_convert_to_rb(args[i], 0, type, &rb_arg, NO);
+      rb_objc_convert_to_rb(args[i], 0, type, &rb_arg);
       rb_ary_push(rb_array, rb_arg);
     }
 
@@ -1250,7 +1250,7 @@ rb_objc_dispatch(id rcv, const char *method, NSMethodSignature *signature, int r
     }
     
     if (ret_type != &ffi_type_void) {
-      rb_objc_convert_to_rb(data, 0, type, &rb_retval, NO);
+      rb_objc_convert_to_rb(data, 0, type, &rb_retval);
     }
   }
 
@@ -1296,7 +1296,7 @@ rb_objc_send(int rigs_argc, VALUE *rigs_argv, VALUE rb_self)
                  (void*)rb_self, NSStringFromClass([rcv classForCoder]), DATA_PTR(rb_self), rcv);
       break;
     case T_CLASS:
-      rcv = (Class) NUM2LL(rb_iv_get(rb_self, "@objc_class"));
+      rcv = (Class)NUM2LL(rb_iv_get(rb_self, "@objc_class"));
       NSDebugLog(@"Self is Ruby class (%p): %@", (void*)rb_self, NSStringFromClass([rcv classForCoder]));
       break;
     default:
@@ -1471,7 +1471,7 @@ rb_objc_register_constant_from_objc(const char *name, const char *type)
   data = dlsym(RTLD_DEFAULT, name);
 
   if (data != NULL) {
-    if (rb_objc_convert_to_rb(data, 0, type, &rb_retval, YES)) {
+    if (rb_objc_convert_to_rb(data, 0, type, &rb_retval)) {
       rb_define_const(rb_mRigs, name, rb_retval);
     }
   }
@@ -1605,12 +1605,14 @@ rb_objc_register_class_from_objc (Class objc_class)
 
   // Extend any extra Ruby specific support to Objective-C classes
   if (objc_class == [NSObject class]) {
-    rb_define_alias(rb_class, "==", "isEqual");
-    rb_define_alias(rb_class, "eql?", "isEqual");
+    rb_include_module(rb_class, rb_mKernel);
+    rb_define_method(rb_class, "nil?", rb_objc_false, 0);
+    rb_define_method(rb_class, "<=>", rb_objc_object_compare, 1);
+    rb_define_method(rb_class, "==", rb_objc_object_equal, 1);
+    rb_define_alias(rb_class, "eql?", "==");
     rb_define_method(rb_class, "to_s", rb_objc_object_to_s, 0);
     rb_define_method(rb_class, "inspect", rb_objc_object_inspect, 0);
     rb_define_method(rb_class, "pretty_print", rb_objc_object_pretty_print, 1);
-    rb_define_method(rb_class, "nil?", rb_objc_object_is_nil, 0);
     rb_define_method(rb_class, "instance_of?", rb_objc_object_is_instance_of, 1);
     rb_define_method(rb_class, "kind_of?", rb_objc_object_is_kind_of, 1);
     rb_define_alias(rb_class, "is_a?", "kind_of?");
@@ -1618,33 +1620,63 @@ rb_objc_register_class_from_objc (Class objc_class)
     rb_define_singleton_method(rb_class, "method_added", rb_objc_object_method_added, 1);
   }
   else if (objc_class == [NSString class]) {
+    rb_include_module(rb_class, rb_mComparable);
+    rb_define_method(rb_class, "<=>", rb_objc_string_compare, 1); 
     rb_define_method(rb_class, "to_s", rb_objc_string_to_s, 0);
+    rb_define_alias(rb_class, "to_str", "to_s");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_string_convert, 1);
   }
-  else if (objc_class == [NSMutableString class]) {
-    rb_define_alias(rb_class, "<<", "appendString");
+  else if (objc_class == [NSDate class]) {
+    rb_include_module(rb_class, rb_mComparable);
+    rb_define_method(rb_class, "<=>", rb_objc_date_compare, 1);
+    rb_define_method(rb_class, "to_time", rb_objc_date_to_time, 0);
+    rb_define_module_function(rb_mRigs, cname, rb_objc_date_convert, 1);
+  }
+  else if (objc_class == [NSNumber class]) {
+    rb_include_module(rb_class, rb_mComparable);
+    rb_define_method(rb_class, "<=>", rb_objc_number_compare, 1);
+    rb_define_method(rb_class, "to_i", rb_objc_number_to_i, 0);
+    rb_define_method(rb_class, "to_f", rb_objc_number_to_f, 0);
+    rb_define_alias(rb_class, "to_int", "to_i");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_number_convert, 1);
   }
   else if (objc_class == [NSArray class]) {
-    rb_define_method(rb_class, "to_a", rb_objc_array_to_a, 0);
+    rb_include_module(rb_class, rb_mEnumerable);
+    rb_define_method(rb_class, "each", rb_objc_array_each, 0);
+    rb_define_alias(rb_class, "to_ary", "to_a");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_array_convert, 1);
+  }
+  else if (objc_class == [NSDictionary class]) {
+    rb_include_module(rb_class, rb_mEnumerable);
+    rb_define_method(rb_class, "each_key", rb_objc_dictionary_each_key, 0);
+    rb_define_method(rb_class, "each_value", rb_objc_dictionary_each_value, 0);
+    rb_define_method(rb_class, "each_pair", rb_objc_dictionary_each_pair, 0);
+    rb_define_alias(rb_class, "each", "each_pair");
+    rb_define_alias(rb_class, "to_hash", "to_h");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_dictionary_convert, 1);
+  }
+  else if (objc_class == [NSSet class]) {
+    rb_include_module(rb_class, rb_mEnumerable);
+    rb_define_method(rb_class, "each", rb_objc_array_each, 0);
+    rb_define_module_function(rb_mRigs, cname, rb_objc_set_convert, 1);
   }
   else if (objc_class == [NSMutableArray class]) {
     rb_define_method(rb_class, "[]=", rb_objc_array_store, 2);
     rb_define_alias(rb_class, "<<", "addObject");
-  }
-  else if (objc_class == [NSMutableOrderedSet class]) {
-    rb_define_method(rb_class, "[]=", rb_objc_array_store, 2);
-  }
-  else if (objc_class == [NSDictionary class]) {
-    rb_define_method(rb_class, "to_h", rb_objc_dictionary_to_h, 0);
+    rb_define_module_function(rb_mRigs, cname, rb_objc_array_m_convert, 1);
   }
   else if (objc_class == [NSMutableDictionary class]) {
     rb_define_method(rb_class, "[]=", rb_objc_dictionary_store, 2);
+    rb_define_module_function(rb_mRigs, cname, rb_objc_dictionary_m_convert, 1);
   }
-  else if (objc_class == [NSDate class]) {
-    rb_define_method(rb_class, "to_time", rb_objc_date_to_time, 0);
+  else if (objc_class == [NSMutableSet class]) {
+    rb_define_method(rb_class, "[]=", rb_objc_array_store, 2);
+    rb_define_alias(rb_class, "<<", "addObject");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_set_m_convert, 1);
   }
-  else if (objc_class == [NSNumber class]) {
-    rb_define_method(rb_class, "to_i", rb_objc_number_to_i, 0);
-    rb_define_method(rb_class, "to_f", rb_objc_number_to_f, 0);
+  else if (objc_class == [NSMutableString class]) {
+    rb_define_alias(rb_class, "<<", "appendString");
+    rb_define_module_function(rb_mRigs, cname, rb_objc_string_m_convert, 1);
   }
   else if (objc_class == [NSMutableData class]) {
     rb_define_alias(rb_class, "<<", "appendData");
@@ -1678,7 +1710,7 @@ rb_objc_register_instance_method_from_rb(VALUE rb_class, VALUE rb_method)
     return Qfalse;
   }
   
-  class = (Class) NUM2LL(rb_class_iv);
+  class = (Class)NUM2LL(rb_class_iv);
   entry = rb_sym2id(rb_method);
   nbArgs = rb_mod_method_arity(rb_class, entry);
 
@@ -1748,7 +1780,7 @@ rb_objc_register_class_from_rb(VALUE rb_class)
     if (rb_class_iv == Qnil) {
       rb_raise(rb_eTypeError, "superclass of %s was not yet registered with the Objective-C runtime", rb_class_name);
     }
-    superClass = (Class) NUM2LL(rb_class_iv);
+    superClass = (Class)NUM2LL(rb_class_iv);
     
     class = objc_allocateClassPair(superClass, rb_class_name, 0);
     if (class == nil) {
@@ -1841,6 +1873,12 @@ rb_objc_import(VALUE rb_self, VALUE rb_name)
   }
 }
 
+VALUE
+rb_objc_false(VALUE rb_self)
+{
+  return Qfalse;
+}
+
 void __attribute__((noreturn))
   rb_objc_raise_exception(NSException *exception)
 {
@@ -1887,4 +1925,9 @@ Init_obj_ext()
   // Ruby error class for raising all Objective-C runtime exceptions
   // - rescue ObjRuby::RuntimeError: error raised from Objective-C
   rb_eRigsRuntimeError = rb_define_class_under(rb_mRigs, "RuntimeError", rb_eRuntimeError);
+
+  // rb_cSet doesn't have a C API
+  rb_cSet = rb_const_get(rb_cObject, rb_intern("Set"));
+
+  rb_objc_register_class_from_objc([NSObject class]);
 }

--- a/ext/obj_ext/RIGSNSArray.h
+++ b/ext/obj_ext/RIGSNSArray.h
@@ -26,9 +26,12 @@
 #include <ruby.h>
 #include <objc/runtime.h>
 
+VALUE rb_objc_array_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_array_m_convert(VALUE rb_module, VALUE rb_val);
+
+VALUE rb_objc_array_each(VALUE rb_self);
 VALUE rb_objc_array_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val);
-VALUE rb_objc_array_to_a(VALUE rb_self);
-VALUE rb_objc_array_to_rb(NSArray *val);
-NSArray* rb_objc_array_from_rb(VALUE rb_val);
+
+id rb_objc_array_from_rb(VALUE rb_val, VALUE rb_frozen);
 
 #endif

--- a/ext/obj_ext/RIGSNSArray.m
+++ b/ext/obj_ext/RIGSNSArray.m
@@ -22,6 +22,91 @@
 #import "RIGSNSArray.h"
 #import "RIGSCore.h"
 
+static VALUE
+rb_objc_array_i_convert(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
+{
+  @autoreleasepool {
+    NSMutableArray *ary;
+    id elt;
+    void *data;
+    const char idType[] = {_C_ID,'\0'};
+
+    ary = (NSMutableArray *)memo;
+    data = alloca(sizeof(id));
+    data = &elt;
+
+    rb_objc_convert_to_objc(i, &data, 0, idType);
+    [ary addObject:elt];
+
+    return Qnil;
+  }  
+}
+
+static VALUE
+rb_objc_array_enum_size(VALUE ary, VALUE args, VALUE eobj)
+{
+  @autoreleasepool {
+    id rcv;
+
+    Data_Get_Struct(ary, void, rcv);
+
+    return ULONG2NUM([rcv count]);
+  }  
+}
+
+VALUE
+rb_objc_array_convert(VALUE rb_module, VALUE rb_val)
+{
+  @autoreleasepool {
+    NSArray *objc_ary;
+    VALUE rb_ary;
+    const char idType[] = {_C_ID,'\0'};
+
+    objc_ary = rb_objc_array_from_rb(rb_val, Qtrue);
+
+    rb_objc_convert_to_rb((void *)&objc_ary, 0, idType, &rb_ary);
+
+    return rb_ary;
+  }
+}
+
+VALUE
+rb_objc_array_m_convert(VALUE rb_module, VALUE rb_val)
+{
+  @autoreleasepool {
+    NSMutableArray *objc_ary;
+    VALUE rb_ary;
+    const char idType[] = {_C_ID,'\0'};
+
+    objc_ary = rb_objc_array_from_rb(rb_val, Qfalse);
+
+    rb_objc_convert_to_rb((void *)&objc_ary, 0, idType, &rb_ary);
+
+    return rb_ary;
+  }
+}
+
+VALUE
+rb_objc_array_each(VALUE rb_self)
+{
+  @autoreleasepool {
+    id rcv;
+    VALUE rb_elt;
+    const char idType[] = {_C_ID,'\0'};
+
+    Data_Get_Struct(rb_self, void, rcv);
+
+    RETURN_SIZED_ENUMERATOR(rb_self, 0, 0, rb_objc_array_enum_size);
+
+    for (id objc_elt in rcv) {
+      rb_objc_convert_to_rb((void *)&objc_elt, 0, idType, &rb_elt);
+      rb_yield(rb_elt);
+    }
+
+    return rb_self;
+  }  
+}
+
 VALUE
 rb_objc_array_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val)
 {
@@ -45,67 +130,17 @@ rb_objc_array_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val)
   }
 }
 
-VALUE
-rb_objc_array_to_a(VALUE rb_self)
+id
+rb_objc_array_from_rb(VALUE rb_val, VALUE rb_frozen)
 {
-  @autoreleasepool {
-    id rcv;
+  NSMutableArray *ary;
 
-    Data_Get_Struct(rb_self, void, rcv);
+  ary = [NSMutableArray array];
+  rb_block_call(rb_val, rb_intern("each"), 0, 0, rb_objc_array_i_convert, (VALUE)ary);
 
-    return rb_objc_array_to_rb(rcv);
-  }  
-}
-
-VALUE
-rb_objc_array_to_rb(NSArray *rcv)
-{
-  VALUE rb_array;
-  VALUE rb_elt;
-  const char idType[] = {_C_ID,'\0'};
-
-  rb_array = rb_ary_new_capa([rcv count]);
-
-  for (id objc_elt in rcv) {
-    rb_objc_convert_to_rb((void *)&objc_elt, 0, idType, &rb_elt, YES);
-    rb_ary_push(rb_array, rb_elt);
-  }
-  
-  return rb_array;
-}
-
-NSArray*
-rb_objc_array_from_rb(VALUE rb_val)
-{
-  NSArray *array;
-  long i;
-  long count;
-  id *objects;
-  VALUE rb_elt;
-  void *data;
-  const char idType[] = {_C_ID,'\0' };
-
-  Check_Type(rb_val, T_ARRAY);
-    
-  // Loop through the elements of the ruby array and generate a NSArray
-  count = rb_array_len(rb_val);
-  objects = malloc(sizeof(id) * count);
-  if (objects == NULL) {
-    return nil;
+  if (rb_frozen == Qtrue) {
+    return [ary copy];
   }
 
-  // Loop through the elements of the ruby array, convert them to Objective-C
-  // objects (only Objects id can go into an NSArray anyway) and feed them
-  // into a new NSArray
-  for (i = 0; i < count; i++) {
-    rb_elt = rb_ary_entry(rb_val, i);
-
-    data = &objects[i];
-    rb_objc_convert_to_objc(rb_elt, &data, 0, idType);
-  }
-
-  array = [NSArray arrayWithObjects:objects count:count];
-  free(objects);
-
-  return array;
+  return ary;
 }

--- a/ext/obj_ext/RIGSNSDate.h
+++ b/ext/obj_ext/RIGSNSDate.h
@@ -27,8 +27,10 @@
 #include <math.h>
 #include <time.h>
 
+VALUE rb_objc_date_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_date_compare(VALUE rb_self, VALUE rb_val);
 VALUE rb_objc_date_to_time(VALUE rb_self);
-VALUE rb_objc_date_to_rb(NSDate *val);
+
 NSDate* rb_objc_date_from_rb(VALUE rb_val);
 
 #endif

--- a/ext/obj_ext/RIGSNSDictionary.h
+++ b/ext/obj_ext/RIGSNSDictionary.h
@@ -26,9 +26,13 @@
 #include <ruby.h>
 #include <objc/runtime.h>
 
+VALUE rb_objc_dictionary_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_dictionary_m_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_dictionary_each_key(VALUE rb_self);
+VALUE rb_objc_dictionary_each_value(VALUE rb_self);
+VALUE rb_objc_dictionary_each_pair(VALUE rb_self);
 VALUE rb_objc_dictionary_store(VALUE rb_self, VALUE rb_key, VALUE rb_val);
-VALUE rb_objc_dictionary_to_h(VALUE rb_self);
-VALUE rb_objc_dictionary_to_rb(NSDictionary *val);
-NSDictionary* rb_objc_dictionary_from_rb(VALUE rb_val);
+
+id rb_objc_dictionary_from_rb(VALUE rb_val, VALUE rb_frozen);
 
 #endif

--- a/ext/obj_ext/RIGSNSNumber.h
+++ b/ext/obj_ext/RIGSNSNumber.h
@@ -26,9 +26,11 @@
 #include <ruby.h>
 #include <objc/runtime.h>
 
+VALUE rb_objc_number_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_number_compare(VALUE rb_self, VALUE rb_val);
 VALUE rb_objc_number_to_i(VALUE rb_self);
 VALUE rb_objc_number_to_f(VALUE rb_self);
-VALUE rb_objc_number_to_rb(NSNumber *val);
+
 NSNumber* rb_objc_number_from_rb(VALUE rb_val);
 
 #endif

--- a/ext/obj_ext/RIGSNSObject.h
+++ b/ext/obj_ext/RIGSNSObject.h
@@ -25,10 +25,11 @@
 #import <Foundation/Foundation.h>
 #include <ruby.h>
 
+VALUE rb_objc_object_compare(VALUE rb_self, VALUE rb_val);
+VALUE rb_objc_object_equal(VALUE rb_self, VALUE rb_val);
 VALUE rb_objc_object_to_s(VALUE rb_self);
 VALUE rb_objc_object_inspect(VALUE rb_self);
 VALUE rb_objc_object_pretty_print(VALUE rb_self, VALUE rb_pp);
-VALUE rb_objc_object_is_nil(VALUE rb_self);
 VALUE rb_objc_object_is_kind_of(VALUE rb_self, VALUE rb_class);
 VALUE rb_objc_object_is_instance_of(VALUE rb_self, VALUE rb_class);
 VALUE rb_objc_object_inherited(VALUE rb_class, VALUE rb_subclass);

--- a/ext/obj_ext/RIGSNSObject.m
+++ b/ext/obj_ext/RIGSNSObject.m
@@ -23,6 +23,74 @@
 #import "RIGSCore.h"
 
 VALUE
+rb_objc_object_compare(VALUE rb_self, VALUE rb_val)
+{
+  @autoreleasepool {
+    id rcv;
+    id objc_val;
+
+    if (NIL_P(rb_val)) {
+      return Qnil;
+    }
+    
+    if (rb_self == rb_val) {
+      return INT2FIX(0);
+    }
+
+    if (rb_iv_get(CLASS_OF(rb_val), "@objc_class") == Qnil) {
+      return Qnil;
+    }
+
+    Data_Get_Struct(rb_self, void, rcv);
+    Data_Get_Struct(rb_val, void, objc_val);
+
+    if (rcv == objc_val) {
+      return INT2FIX(0);
+    }
+
+    if ([rcv isEqual:objc_val]) {
+      return INT2FIX(0);
+    }
+
+    return Qnil;
+  }
+}
+
+VALUE
+rb_objc_object_equal(VALUE rb_self, VALUE rb_val)
+{
+  @autoreleasepool {
+    id rcv;
+    id objc_val;
+
+    if (NIL_P(rb_val)) {
+      return Qfalse;
+    }
+    
+    if (rb_self == rb_val) {
+      return Qtrue;
+    }
+
+    if (rb_iv_get(CLASS_OF(rb_val), "@objc_class") == Qnil) {
+      return Qfalse;
+    }
+
+    Data_Get_Struct(rb_self, void, rcv);
+    Data_Get_Struct(rb_val, void, objc_val);
+
+    if (rcv == objc_val) {
+      return Qtrue;
+    }
+
+    if ([rcv isEqual:objc_val]) {
+      return Qtrue;
+    }
+
+    return Qfalse;
+  }
+}
+
+VALUE
 rb_objc_object_to_s(VALUE rb_self)
 {
   @autoreleasepool {
@@ -62,35 +130,19 @@ rb_objc_object_pretty_print(VALUE rb_self, VALUE rb_pp)
 }
 
 VALUE
-rb_objc_object_is_nil(VALUE rb_self)
-{
-  @autoreleasepool {
-    id rcv;
-  
-    Data_Get_Struct(rb_self, void, rcv);
-
-    if (rcv == nil) {
-      return Qtrue;
-    }
-
-    return Qfalse;
-  }
-}
-
-VALUE
 rb_objc_object_is_kind_of(VALUE rb_self, VALUE rb_class)
 {
   @autoreleasepool {
     id rcv;
-    VALUE iv;
     Class objc_class;
+    VALUE iv;
 
     iv = rb_iv_get(rb_class, "@objc_class");
     if (iv == Qnil) {
       return Qfalse;
     }
 
-    objc_class = (Class) NUM2LL(iv);
+    objc_class = (Class)NUM2LL(iv);
     Data_Get_Struct(rb_self, void, rcv);
 
     if ([[rcv classForCoder] isSubclassOfClass:objc_class]) {
@@ -106,15 +158,15 @@ rb_objc_object_is_instance_of(VALUE rb_self, VALUE rb_class)
 {
   @autoreleasepool {
     id rcv;
-    VALUE iv;
     Class objc_class;
+    VALUE iv;
 
     iv = rb_iv_get(rb_class, "@objc_class");
     if (iv == Qnil) {
       return Qfalse;
     }
 
-    objc_class = (Class) NUM2LL(iv);
+    objc_class = (Class)NUM2LL(iv);
     Data_Get_Struct(rb_self, void, rcv);
 
     if ([rcv classForCoder] == objc_class) {

--- a/ext/obj_ext/RIGSNSSet.h
+++ b/ext/obj_ext/RIGSNSSet.h
@@ -1,8 +1,8 @@
-/* RIGSNSString.h - Some additional stuff to properly wrap the
-   NSString class in Ruby
+/* RIGSNSSet.h - Some additional to properly wrap the
+   NSSet class in Ruby and provide some new methods
 
    Written by: Ryan Krug <keegnotrub@icloud.com>
-   Date: April 2023
+   Date: June 2025
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -19,17 +19,15 @@
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 */ 
 
-#ifndef __RIGSNSString_h_GNUSTEP_RUBY_INCLUDE
-#define __RIGSNSString_h_GNUSTEP_RUBY_INCLUDE
+#ifndef __RIGSNSSet_h_GNUSTEP_RUBY_INCLUDE
+#define __RIGSNSSet_h_GNUSTEP_RUBY_INCLUDE
 
 #import <Foundation/Foundation.h>
 #include <ruby.h>
 
-VALUE rb_objc_string_convert(VALUE rb_module, VALUE rb_val);
-VALUE rb_objc_string_m_convert(VALUE rb_module, VALUE rb_val);
-VALUE rb_objc_string_compare(VALUE rb_self, VALUE rb_val);
-VALUE rb_objc_string_to_s(VALUE rb_self);
+VALUE rb_objc_set_convert(VALUE rb_module, VALUE rb_val);
+VALUE rb_objc_set_m_convert(VALUE rb_module, VALUE rb_val);
 
-id rb_objc_string_from_rb(VALUE rb_val, VALUE rb_frozen);
+id rb_objc_set_from_rb(VALUE rb_val, VALUE rb_frozen);
 
 #endif

--- a/ext/obj_ext/RIGSNSSet.m
+++ b/ext/obj_ext/RIGSNSSet.m
@@ -1,0 +1,90 @@
+/* RIGSNSSet.m - Some additional to properly wrap the
+   NSSet class in Ruby and provide some new methods
+
+   Written by: Ryan Krug <keegnotrub@icloud.com>
+   Date: June 2025
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA.
+*/ 
+
+#import "RIGSNSSet.h"
+#import "RIGSCore.h"
+
+static VALUE
+rb_objc_set_i_convert(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
+{
+  @autoreleasepool {
+    NSMutableSet *set;
+    id elt;
+    void *data;
+    const char idType[] = {_C_ID,'\0'};
+
+    set = (NSMutableSet *)memo;
+    data = alloca(sizeof(id));
+    data = &elt;
+
+    rb_objc_convert_to_objc(i, &data, 0, idType);
+    [set addObject:elt];
+
+    return Qnil;
+  }  
+}
+
+VALUE
+rb_objc_set_convert(VALUE rb_module, VALUE rb_val)
+{
+  @autoreleasepool {
+    NSSet *objc_set;
+    VALUE rb_set;
+    const char idType[] = {_C_ID,'\0'};
+
+    objc_set = rb_objc_set_from_rb(rb_val, Qtrue);
+
+    rb_objc_convert_to_rb((void *)&objc_set, 0, idType, &rb_set);
+
+    return rb_set;
+  }
+}
+
+VALUE
+rb_objc_set_m_convert(VALUE rb_module, VALUE rb_val)
+{
+  @autoreleasepool {
+    NSSet *objc_set;
+    VALUE rb_set;
+    const char idType[] = {_C_ID,'\0'};
+
+    objc_set = rb_objc_set_from_rb(rb_val, Qfalse);
+
+    rb_objc_convert_to_rb((void *)&objc_set, 0, idType, &rb_set);
+
+    return rb_set;
+  }
+}
+
+id
+rb_objc_set_from_rb(VALUE rb_val, VALUE rb_frozen)
+{
+  NSMutableSet *set;
+
+  set = [NSMutableSet set];
+  rb_block_call(rb_val, rb_intern("each"), 0, 0, rb_objc_set_i_convert, (VALUE)set);
+
+  if (rb_frozen == Qtrue) {
+    return [set copy];
+  }
+
+  return set;
+}

--- a/ext/obj_ext/RIGSPointer.m
+++ b/ext/obj_ext/RIGSPointer.m
@@ -206,7 +206,7 @@ rb_objc_ptr_at(VALUE rb_val, int index) {
   
   if (offset + tsize > dp->allocated_size) return Qnil;
 
-  rb_objc_convert_to_rb(dp->cptr, offset, dp->encoding, &val, NO);
+  rb_objc_convert_to_rb(dp->cptr, offset, dp->encoding, &val);
 
   return val;
 }
@@ -246,7 +246,7 @@ rb_objc_ptr_slice(VALUE rb_val, int index, int length)
   rb_array = rb_ary_new();
 
   while(length-- > 0 && offset < dp->allocated_size) {
-    rb_objc_convert_to_rb(dp->cptr, offset, dp->encoding, &rb_elt, NO);
+    rb_objc_convert_to_rb(dp->cptr, offset, dp->encoding, &rb_elt);
     rb_ary_push(rb_array, rb_elt);
 
     offset += tsize;

--- a/spec/obj_ruby/ns_array_spec.rb
+++ b/spec/obj_ruby/ns_array_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe ObjRuby::NSArray do
   it "can be indexed with a subscript" do
     array = described_class.arrayWithArray([1, 2, "hi", 4, 5])
 
-    expect(array[1]).to eq(2)
-    expect(array[2]).to eq("hi")
+    expect(array[1]).to eq ObjRuby::NSNumber(2)
+    expect(array[2]).to eq ObjRuby::NSString("hi")
   end
 
   it "can be transformed into a Ruby array" do
@@ -57,7 +57,7 @@ RSpec.describe ObjRuby::NSArray do
 
     expect(result).to be_a Array
     expect(result.size).to eq 5
-    expect(result[0]).to eq 1
+    expect(result[0]).to eq ObjRuby::NSNumber(1)
   end
 
   it "can use a block method" do
@@ -80,7 +80,7 @@ RSpec.describe ObjRuby::NSArray do
     end
 
     expect(result.hasChanges).to be true
-    expect(result.insertions.count).to be 2
-    expect(result.removals.count).to be 2
+    expect(result.insertions.count).to eq 2
+    expect(result.removals.count).to eq 2
   end
 end

--- a/spec/obj_ruby/ns_dictionary_spec.rb
+++ b/spec/obj_ruby/ns_dictionary_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe ObjRuby::NSDictionary do
     dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
 
     expect(dict.count).to eq 2
-    expect(dict.objectForKey(:key1)).to eq "value1"
-    expect(dict.objectForKey(:key2)).to eq "value2"
+    expect(dict.objectForKey(:key1)).to eq ObjRuby::NSString("value1")
+    expect(dict.objectForKey(:key2)).to eq ObjRuby::NSString("value2")
     expect(dict.objectForKey(:not_key)).to be_nil
   end
 
@@ -23,8 +23,8 @@ RSpec.describe ObjRuby::NSDictionary do
     dict = described_class.dictionaryWithObjectsAndKeys("value1", :key1, "value2", :key2, nil)
 
     expect(dict.count).to eq 2
-    expect(dict.objectForKey(:key1)).to eq "value1"
-    expect(dict.objectForKey(:key2)).to eq "value2"
+    expect(dict.objectForKey(:key1)).to eq ObjRuby::NSString("value1")
+    expect(dict.objectForKey(:key2)).to eq ObjRuby::NSString("value2")
     expect(dict.objectForKey(:not_key)).to be_nil
   end
 
@@ -38,8 +38,8 @@ RSpec.describe ObjRuby::NSDictionary do
   it "can be keyed with a subscript" do
     dict = described_class.dictionaryWithDictionary(key1: "value1", key2: "value2")
 
-    expect(dict[:key1]).to eq("value1")
-    expect(dict[:key2]).to eq("value2")
+    expect(dict[:key1]).to eq ObjRuby::NSString("value1")
+    expect(dict[:key2]).to eq ObjRuby::NSString("value2")
   end
 
   it "can be transformed into a Ruby hash" do
@@ -48,7 +48,7 @@ RSpec.describe ObjRuby::NSDictionary do
     hash = dict.to_h
 
     expect(hash).to be_a Hash
-    expect(hash["key1"]).to eq "value1"
-    expect(hash["key2"]).to eq "value2"
+    expect(hash[ObjRuby::NSString("key1")]).to eq ObjRuby::NSString("value1")
+    expect(hash[ObjRuby::NSString("key2")]).to eq ObjRuby::NSString("value2")
   end
 end

--- a/spec/obj_ruby/ns_mutable_array_spec.rb
+++ b/spec/obj_ruby/ns_mutable_array_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe ObjRuby::NSMutableArray do
       array << "three"
     end.to change(array, :count).by(3)
 
-    expect(array[0]).to eq("one")
-    expect(array[1]).to eq("two")
-    expect(array[2]).to eq("three")
+    expect(array[0]).to eq ObjRuby::NSString("one")
+    expect(array[1]).to eq ObjRuby::NSString("two")
+    expect(array[2]).to eq ObjRuby::NSString("three")
   end
 
   it "can add objects by indexed subscript" do
@@ -33,9 +33,9 @@ RSpec.describe ObjRuby::NSMutableArray do
       array[2] = "three"
     end.to change(array, :count).by(3)
 
-    expect(array[0]).to eq("one")
-    expect(array[1]).to eq("two")
-    expect(array[2]).to eq("three")
+    expect(array[0]).to eq ObjRuby::NSString("one")
+    expect(array[1]).to eq ObjRuby::NSString("two")
+    expect(array[2]).to eq ObjRuby::NSString("three")
   end
 
   it "can replace objects" do
@@ -47,9 +47,9 @@ RSpec.describe ObjRuby::NSMutableArray do
       array.replaceObjectAtIndex_withObject(2, "three")
     end.not_to change(array, :count)
 
-    expect(array[0]).to eq("one")
-    expect(array[1]).to eq("two")
-    expect(array[2]).to eq("three")
+    expect(array[0]).to eq ObjRuby::NSString("one")
+    expect(array[1]).to eq ObjRuby::NSString("two")
+    expect(array[2]).to eq ObjRuby::NSString("three")
   end
 
   it "can replace objects by indexed subscript" do
@@ -61,9 +61,9 @@ RSpec.describe ObjRuby::NSMutableArray do
       array[2] = "three"
     end.not_to change(array, :count)
 
-    expect(array[0]).to eq("one")
-    expect(array[1]).to eq("two")
-    expect(array[2]).to eq("three")
+    expect(array[0]).to eq ObjRuby::NSString("one")
+    expect(array[1]).to eq ObjRuby::NSString("two")
+    expect(array[2]).to eq ObjRuby::NSString("three")
   end
 
   it "can remove objects" do
@@ -73,7 +73,7 @@ RSpec.describe ObjRuby::NSMutableArray do
       array.removeObject(2)
     end.to change(array, :count).by(-1)
 
-    expect(array[0]).to eq(1)
-    expect(array[1]).to eq(3)
+    expect(array[0]).to eq ObjRuby::NSNumber(1)
+    expect(array[1]).to eq ObjRuby::NSNumber(3)
   end
 end

--- a/spec/obj_ruby/ns_mutable_dictionary_spec.rb
+++ b/spec/obj_ruby/ns_mutable_dictionary_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe ObjRuby::NSMutableDictionary do
       dict.setObject_forKey(3, "three")
     end.to change(dict, :count).by(3)
 
-    expect(dict["one"]).to eq(1)
-    expect(dict["two"]).to eq(2)
-    expect(dict["three"]).to eq(3)
+    expect(dict["one"]).to eq ObjRuby::NSNumber(1)
+    expect(dict["two"]).to eq ObjRuby::NSNumber(2)
+    expect(dict["three"]).to eq ObjRuby::NSNumber(3)
   end
 
   it "can add entries by keyed subscript" do
@@ -33,9 +33,9 @@ RSpec.describe ObjRuby::NSMutableDictionary do
       dict["three"] = 3
     end.to change(dict, :count).by(3)
 
-    expect(dict["one"]).to eq(1)
-    expect(dict["two"]).to eq(2)
-    expect(dict["three"]).to eq(3)
+    expect(dict["one"]).to eq ObjRuby::NSNumber(1)
+    expect(dict["two"]).to eq ObjRuby::NSNumber(2)
+    expect(dict["three"]).to eq ObjRuby::NSNumber(3)
   end
 
   it "can replace entries" do
@@ -46,8 +46,8 @@ RSpec.describe ObjRuby::NSMutableDictionary do
       dict.setObject_forKey("value2!", :key2)
     end.not_to change(dict, :count)
 
-    expect(dict[:key1]).to eq("value1!")
-    expect(dict[:key2]).to eq("value2!")
+    expect(dict[:key1]).to eq ObjRuby::NSString("value1!")
+    expect(dict[:key2]).to eq ObjRuby::NSString("value2!")
   end
 
   it "can replace entries by keyed subscript" do
@@ -58,8 +58,8 @@ RSpec.describe ObjRuby::NSMutableDictionary do
       dict[:key2] = "value2!"
     end.not_to change(dict, :count)
 
-    expect(dict[:key1]).to eq("value1!")
-    expect(dict[:key2]).to eq("value2!")
+    expect(dict[:key1]).to eq ObjRuby::NSString("value1!")
+    expect(dict[:key2]).to eq ObjRuby::NSString("value2!")
   end
 
   it "can remove entries" do
@@ -70,6 +70,6 @@ RSpec.describe ObjRuby::NSMutableDictionary do
     end.to change(dict, :count).by(-1)
 
     expect(dict[:key1]).to be_nil
-    expect(dict[:key2]).to eq("value2")
+    expect(dict[:key2]).to eq ObjRuby::NSString("value2")
   end
 end

--- a/spec/obj_ruby/ns_object_spec.rb
+++ b/spec/obj_ruby/ns_object_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ObjRuby::NSObject do
       result = obj.performSelector(:myObjcMethod)
 
       expect(result).to be_a ObjRuby::NSString
-      expect(result).to eq "expected myObjcMethod return"
+      expect(result).to eq ObjRuby::NSString("expected myObjcMethod return")
       expect(obj.respondsToSelector("myObjcMethod")).to be(true)
     end
 
@@ -65,7 +65,7 @@ RSpec.describe ObjRuby::NSObject do
       result = obj.performSelector_withObject("myObjcMethodWithArg:", "1")
 
       expect(result).to be_a ObjRuby::NSString
-      expect(result).to eq "expected myObjcMethodWithArg(1) return"
+      expect(result).to eq ObjRuby::NSString("expected myObjcMethodWithArg(1) return")
       expect(obj.respondsToSelector("myObjcMethodWithArg")).to be(false)
       expect(obj.respondsToSelector("myObjcMethodWithArg:")).to be(true)
     end
@@ -76,7 +76,7 @@ RSpec.describe ObjRuby::NSObject do
       result = obj.performSelector_withObject_withObject("myObjcMethodWithArg1:andArg2:", "1", "2")
 
       expect(result).to be_a ObjRuby::NSString
-      expect(result).to eq "expected myObjcMethodWithArg1_andArg2(1, 2) return"
+      expect(result).to eq ObjRuby::NSString("expected myObjcMethodWithArg1_andArg2(1, 2) return")
       expect(obj.respondsToSelector("myObjcMethodWithArg1_andArg2")).to be(false)
       expect(obj.respondsToSelector("myObjcMethodWithArg1_andArg2:")).to be(false)
       expect(obj.respondsToSelector("myObjcMethodWithArg1:andArg2:")).to be(true)

--- a/spec/obj_ruby/ns_point_spec.rb
+++ b/spec/obj_ruby/ns_point_spec.rb
@@ -42,6 +42,6 @@ RSpec.describe ObjRuby::NSPoint do
     result = ObjRuby::NSStringFromPoint(point)
 
     expect(result).to be_a ObjRuby::NSString
-    expect(result).to eq "{1, 2}"
+    expect(result).to eq ObjRuby::NSString("{1, 2}")
   end
 end

--- a/spec/obj_ruby/ns_string_spec.rb
+++ b/spec/obj_ruby/ns_string_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe ObjRuby::NSString do
     string = described_class.stringWithFormat("one %d three %@ %d", 2, "four", 5)
 
     expect(string.length).to eq 18
-    expect(string).to eq "one 2 three four 5"
+    expect(string).to eq ObjRuby::NSString("one 2 three four 5")
   end
 
   it "can reeceive a C string" do
     string = described_class.stringWithCString("hello")
 
     expect(string.length).to eq 5
-    expect(string).to eq "hello"
+    expect(string).to eq ObjRuby::NSString("hello")
   end
 
   it "can receive a Ruby string" do
     string = described_class.stringWithString("hello")
 
     expect(string.length).to eq 5
-    expect(string).to eq "hello"
+    expect(string).to eq ObjRuby::NSString("hello")
   end
 
   it "can be transformed to a Ruby string" do

--- a/spec/obj_ruby/pointer_spec.rb
+++ b/spec/obj_ruby/pointer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ObjRuby::Pointer do
       expect(error).not_to be_nil
       expect(error).to be_a ObjRuby::NSError
       expect(error.localizedDescription).to eq(
-        "The file “not-a-path” couldn’t be opened because there is no such file."
+        ObjRuby::NSString("The file “not-a-path” couldn’t be opened because there is no such file.")
       )
       expect(error_ptr[-1]).to eq error
       expect(error_ptr[1]).to be_nil

--- a/spec/obj_ruby_spec.rb
+++ b/spec/obj_ruby_spec.rb
@@ -35,14 +35,18 @@ RSpec.describe ObjRuby do
       expect(described_class.const_get(:NSNotFound)).to eq (2**63) - 1
       expect(described_class.const_get(:NSOrderedSame)).to eq 0
       expect(described_class.const_get(:NSASCIIStringEncoding)).to eq 1
-      expect(described_class.const_get(:NSWeekDayNameArray)).to eq "NSWeekDayNameArray"
+      expect(described_class.const_get(:NSWeekDayNameArray)).to eq(
+        described_class::NSString("NSWeekDayNameArray")
+      )
       expect(described_class.const_get(:NSZombieEnabled)).to be false
     end
 
     it "defines bridged CoreData Objective-C constants" do
       described_class.import("CoreData")
 
-      expect(described_class.const_get(:NSAffectedObjectsErrorKey)).to eq "NSAffectedObjectsErrorKey"
+      expect(described_class.const_get(:NSAffectedObjectsErrorKey)).to eq(
+        described_class::NSString("NSAffectedObjectsErrorKey")
+      )
     end
 
     it "defines bridged AppKit Objective-C constants" do

--- a/spec/support/test_my_object.rb
+++ b/spec/support/test_my_object.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class TestMyObject < ObjRuby::NSObject
-  include ::Kernel
-
   def myObjcMethod
     "expected myObjcMethod return"
   end


### PR DESCRIPTION
NSSet caused a lot of trouble as it doesn't have a C API, however, that made this become more of a introspection on how we should convert between types.

- I don't think we should do autoconvert anymore. I think its okay to convert Ruby stuff into Objective-C stuff when sending it to the Objective-C runtime, but I don't really like just doing stuff like to_x that converts all array or dictionary members to Ruby equivalents.

- Equality is really hard with conversion, I'd prefer we were explicit and say that dict.objectForKey("key) == ObjRuby::NSString("value") than override equality to be able to autoconvert.

- So this ultimately takes the stance of making equality more explicit, but allowing conversion where possible.

Fixes #11 