### PR TITLE
Performance tweak for Array/Dictionary convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ puts earlier_date.isEqualToDate(date) # true
 
 Note you are allowed to mix some Ruby and Objective-C types. The following Ruby types will automatically bridge to these Objective-C types:
 
-| Ruby          | Objective-C            |
-| ------------- | ---------------------- |
-| String        | NSString               |
-| Numeric       | Immediate or NSNumber  |
-| Time          | NSDate                 |
-| Array         | NS{Mutable}Array       |
-| Hash          | NS{Mutable}Dictionary  |
-| Set           | NS{Mutable}Set         |
+| Ruby                 | Objective-C            |
+| -------------------- | ---------------------- |
+| String               | NSString               |
+| Numeric, True, False | Immediate or NSNumber  |
+| Time                 | NSDate                 |
+| Array                | NS{Mutable}Array       |
+| Hash                 | NS{Mutable}Dictionary  |
+| Set                  | NS{Mutable}Set         |
 
 ``` ruby
 require "obj_ruby"

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -134,7 +134,7 @@ rb_objc_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class)
   }
 }
 
-ffi_type*
+static ffi_type*
 rb_objc_ffi_type_for_type(const char *type)
 {
   ffi_type *inStruct = NULL;
@@ -210,7 +210,7 @@ rb_objc_ffi_type_for_type(const char *type)
   }
 }
 
-ffi_status
+static ffi_status
 rb_objc_build_closure_cif(ffi_cif *cif, const char *objcTypes)
 {
   NSMethodSignature *signature;
@@ -237,7 +237,7 @@ rb_objc_build_closure_cif(ffi_cif *cif, const char *objcTypes)
   return ffi_prep_cif(cif, FFI_DEFAULT_ABI, nbArgs, ret_type, arg_types);
 }
 
-const char *
+static const char *
 rb_objc_types_for_selector(SEL sel, size_t nbArgs) {
   char *objcTypes;
   unsigned long hash;
@@ -900,7 +900,7 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
 
 }
 
-NSMethodSignature*
+static NSMethodSignature*
 rb_objc_signature_with_format_string(NSMethodSignature *signature, const char *formatString, int nbArgsExtra)
 {
   char objcTypes[128];
@@ -991,7 +991,7 @@ rb_objc_signature_with_format_string(NSMethodSignature *signature, const char *f
   return [NSMethodSignature signatureWithObjCTypes:objcTypes];
 }
 
-void
+static void
 rb_objc_proxy_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
   @autoreleasepool {
     id val;
@@ -1049,7 +1049,7 @@ rb_objc_proxy_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
   }
 }
 
-void
+static void
 rb_objc_block_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
   @autoreleasepool {
     struct rb_objc_block *block;
@@ -1091,7 +1091,7 @@ rb_objc_block_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
   }
 }
 
-VALUE
+static VALUE
 rb_objc_dispatch(id rcv, const char *method, NSMethodSignature *signature, int rigs_argc, VALUE *rigs_argv)
 {
   void *sym;
@@ -1355,7 +1355,7 @@ rb_objc_invoke(int rigs_argc, VALUE *rigs_argv, VALUE rb_self)
   }  
 }
 
-unsigned int
+static unsigned int
 rb_objc_register_instance_methods(Class objc_class, VALUE rb_class)
 {
   SEL mthSel;
@@ -1390,7 +1390,7 @@ rb_objc_register_instance_methods(Class objc_class, VALUE rb_class)
   return imth_cnt;    
 }
 
-unsigned int
+static unsigned int
 rb_objc_register_class_methods(Class objc_class, VALUE rb_class)
 {
   SEL mthSel;

--- a/ext/obj_ext/RIGSNSArray.m
+++ b/ext/obj_ext/RIGSNSArray.m
@@ -23,14 +23,12 @@
 #import "RIGSCore.h"
 
 static int
-rb_objc_array_i_convert(VALUE i, VALUE memo)
+rb_objc_array_i_convert(VALUE i, NSMutableArray *ary)
 {
-  NSMutableArray *ary;
   id elt;
   void *data;
   const char idType[] = {_C_ID,'\0'};
 
-  ary = (NSMutableArray *)memo;
   data = alloca(sizeof(id));
   data = &elt;
 
@@ -139,11 +137,11 @@ rb_objc_array_from_rb(VALUE rb_val, VALUE rb_frozen)
   ary = [NSMutableArray arrayWithCapacity:length];
 
   for(i=0;i<length;i++) {
-    rb_objc_array_i_convert(rb_ary_entry(rb_val, i), (VALUE)ary);
+    rb_objc_array_i_convert(rb_ary_entry(rb_val, i), ary);
   }
 
   if (rb_frozen == Qtrue) {
-    return [ary copy];
+    return [[ary copy] autorelease];
   }
 
   return ary;

--- a/ext/obj_ext/RIGSNSDictionary.m
+++ b/ext/obj_ext/RIGSNSDictionary.m
@@ -195,7 +195,7 @@ rb_objc_dictionary_from_rb(VALUE rb_val, VALUE rb_frozen)
   rb_hash_foreach(rb_val, rb_objc_dictionary_i_convert, (VALUE)dict);
 
   if (rb_frozen == Qtrue) {
-    return [dict copy];
+    return [[dict copy] autorelease];
   }
   
   return dict;

--- a/ext/obj_ext/RIGSNSSet.m
+++ b/ext/obj_ext/RIGSNSSet.m
@@ -25,21 +25,19 @@
 static VALUE
 rb_objc_set_i_convert(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo))
 {
-  @autoreleasepool {
-    NSMutableSet *set;
-    id elt;
-    void *data;
-    const char idType[] = {_C_ID,'\0'};
+  NSMutableSet *set;
+  id elt;
+  void *data;
+  const char idType[] = {_C_ID,'\0'};
 
-    set = (NSMutableSet *)memo;
-    data = alloca(sizeof(id));
-    data = &elt;
+  set = (NSMutableSet *)memo;
+  data = alloca(sizeof(id));
+  data = &elt;
 
-    rb_objc_convert_to_objc(i, &data, 0, idType);
-    [set addObject:elt];
+  rb_objc_convert_to_objc(i, &data, 0, idType);
+  [set addObject:elt];
 
-    return Qnil;
-  }  
+  return Qnil;
 }
 
 VALUE
@@ -83,7 +81,7 @@ rb_objc_set_from_rb(VALUE rb_val, VALUE rb_frozen)
   rb_block_call(rb_val, rb_intern("each"), 0, 0, rb_objc_set_i_convert, (VALUE)set);
 
   if (rb_frozen == Qtrue) {
-    return [set copy];
+    return [[set copy] autorelease];
   }
 
   return set;


### PR DESCRIPTION
Pre-allocate the size and if we force the check on an T_ARRAY I think we can get away without needing to use a rb_block_call to enumerate.