### PR TITLE
Allow setting ObjRuby::Pointer vals

### DIFF
--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -752,10 +752,10 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
 
       case _C_CHR:
         // Assume that if YES or NO then it's a BOOLean
-        if ( *(char *)where == YES) 
-          rb_val = Qtrue;
-        else if ( *(char *)where == NO)
-          rb_val = Qfalse;
+        if (__OBJC_BOOL_IS_BOOL != 1 && *(char *)where == YES) 
+          rb_val = CHR2FIX(*(char *)where);
+        else if (__OBJC_BOOL_IS_BOOL != 1 && *(char *)where == NO)
+          rb_val = CHR2FIX(*(char *)where);
         else
           rb_val = CHR2FIX(*(char *)where);
         break;
@@ -1919,6 +1919,7 @@ Init_obj_ext()
   rb_define_method(rb_cRigsPtr, "[]", rb_objc_ptr_get, -1);
   rb_define_alias(rb_cRigsPtr, "slice", "[]");
   rb_define_alias(rb_cRigsPtr, "at", "[]");
+  rb_define_method(rb_cRigsPtr, "[]=", rb_objc_ptr_store, 2);
 
   // Ruby error class for raising all Objective-C runtime exceptions
   // - rescue ObjRuby::RuntimeError: error raised from Objective-C

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -753,9 +753,9 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
       case _C_CHR:
         // Assume that if YES or NO then it's a BOOLean
         if (__OBJC_BOOL_IS_BOOL != 1 && *(char *)where == YES) 
-          rb_val = CHR2FIX(*(char *)where);
+          rb_val = Qtrue;
         else if (__OBJC_BOOL_IS_BOOL != 1 && *(char *)where == NO)
-          rb_val = CHR2FIX(*(char *)where);
+          rb_val = Qfalse;
         else
           rb_val = CHR2FIX(*(char *)where);
         break;

--- a/ext/obj_ext/RIGSPointer.h
+++ b/ext/obj_ext/RIGSPointer.h
@@ -28,10 +28,11 @@
 
 VALUE rb_objc_ptr_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class);
 VALUE rb_objc_ptr_get(int rigs_argc, VALUE *rigs_argv, VALUE rb_self);
+VALUE rb_objc_ptr_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val);
 VALUE rb_objc_ptr_inspect(VALUE rb_self);
 
-VALUE rb_objc_ptr_at(VALUE rb_val, int index);
-VALUE rb_objc_ptr_slice(VALUE rb_val, int index, int length);
+VALUE rb_objc_ptr_at(VALUE rb_val, long index);
+VALUE rb_objc_ptr_slice(VALUE rb_val, long index, long length);
 
 void rb_objc_ptr_ref(VALUE rb_val, void **data);
 

--- a/ext/obj_ext/RIGSPointer.m
+++ b/ext/obj_ext/RIGSPointer.m
@@ -169,7 +169,7 @@ rb_objc_ptr_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val)
     index = FIX2INT(rb_idx);
     dp = (struct rb_objc_ptr*)DATA_PTR(rb_self);
 
-    if (dp->allocated_size == 0) rb_raise(rb_eIndexError, "index %ld is invalid for an empty array", index);
+    if (dp->allocated_size == 0) rb_raise(rb_eIndexError, "index %ld is invalid for an empty pointer", index);
 
     tsize = 0;
     NSGetSizeAndAlignment(dp->encoding, &tsize, NULL);
@@ -177,11 +177,11 @@ rb_objc_ptr_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val)
     ioffset = tsize * index;
 
     if (ioffset < 0) ioffset += dp->allocated_size;
-    if (ioffset < 0) rb_raise(rb_eIndexError, "index %ld too small for array", index);
+    if (ioffset < 0) rb_raise(rb_eIndexError, "index %ld too small for pointer", index);
 
     offset = (size_t)ioffset;
 
-    if (offset + tsize > dp->allocated_size) rb_raise(rb_eIndexError, "index %ld too big for array", index);
+    if (offset + tsize > dp->allocated_size) rb_raise(rb_eIndexError, "index %ld too big for pointer", index);
 
     rb_objc_convert_to_objc(rb_val, &(dp->cptr), offset, dp->encoding);
 

--- a/ext/obj_ext/RIGSPointer.m
+++ b/ext/obj_ext/RIGSPointer.m
@@ -21,30 +21,30 @@
 
 #import "RIGSPointer.h"
 #import "RIGSCore.h"
+#import "RIGSUtilities.h"
 
 struct rb_objc_ptr
 {
   unsigned long allocated_size;
   void *cptr;
   const char *encoding;
-  BOOL tainted;
 };
 
 static const char* rb_objc_ptr_types[][2] = {
-  {     "object", "@" },
-  {       "bool", "B" },
-  {       "char", "c" },
-  {      "uchar", "C" },
-  {      "short", "s" },
-  {     "ushort", "S" },
-  {        "int", "i" },
-  {       "uint", "I" },
-  {       "long", "l" },
-  {      "ulong", "L" },
-  {  "long_long", "q" },
-  { "ulong_long", "Q" },
-  {      "float", "f" },
-  {     "double", "d" },
+  {     "object", @encode(id) },
+  {       "bool", @encode(BOOL) },
+  {       "char", @encode(char) },
+  {      "uchar", @encode(unsigned char) },
+  {      "short", @encode(short) },
+  {     "ushort", @encode(unsigned short) },
+  {        "int", @encode(int) },
+  {       "uint", @encode(unsigned int) },
+  {       "long", @encode(long) },
+  {      "ulong", @encode(unsigned long) },
+  {  "long_long", @encode(long long) },
+  { "ulong_long", @encode(unsigned long long) },
+  {      "float", @encode(float) },
+  {     "double", @encode(double) },
   {        NULL, NULL }
 };
 
@@ -60,7 +60,6 @@ rb_objc_ptr_release(struct rb_objc_ptr *dp)
     dp->allocated_size = 0;
     dp->cptr = NULL;
     dp->encoding = NULL;
-    dp->tainted = NO;
 
     free(dp);
   }
@@ -125,7 +124,6 @@ rb_objc_ptr_new(int rigs_argc, VALUE *rigs_argv, VALUE rb_class)
     dp->cptr = (void*)malloc(tsize);
     memset(dp->cptr, 0, tsize);
     dp->allocated_size = tsize;
-    dp->tainted = NO;
 
     obj = Data_Wrap_Struct(rb_class, 0, rb_objc_ptr_release, dp);
 
@@ -157,6 +155,41 @@ rb_objc_ptr_get(int rigs_argc, VALUE *rigs_argv, VALUE rb_self)
 }
 
 VALUE
+rb_objc_ptr_store(VALUE rb_self, VALUE rb_idx, VALUE rb_val)
+{
+  @autoreleasepool {
+    struct rb_objc_ptr *dp;
+    long index;
+    size_t tsize;
+    size_t offset;
+    long ioffset;
+    
+    Check_Type(rb_idx, T_FIXNUM);
+
+    index = FIX2INT(rb_idx);
+    dp = (struct rb_objc_ptr*)DATA_PTR(rb_self);
+
+    if (dp->allocated_size == 0) rb_raise(rb_eIndexError, "index %ld is invalid for an empty array", index);
+
+    tsize = 0;
+    NSGetSizeAndAlignment(dp->encoding, &tsize, NULL);
+
+    ioffset = tsize * index;
+
+    if (ioffset < 0) ioffset += dp->allocated_size;
+    if (ioffset < 0) rb_raise(rb_eIndexError, "index %ld too small for array", index);
+
+    offset = (size_t)ioffset;
+
+    if (offset + tsize > dp->allocated_size) rb_raise(rb_eIndexError, "index %ld too big for array", index);
+
+    rb_objc_convert_to_objc(rb_val, &(dp->cptr), offset, dp->encoding);
+
+    return rb_val;
+  }
+}
+
+VALUE
 rb_objc_ptr_inspect(VALUE rb_self)
 {
   @autoreleasepool {
@@ -179,7 +212,7 @@ rb_objc_ptr_inspect(VALUE rb_self)
 }
 
 VALUE
-rb_objc_ptr_at(VALUE rb_val, int index) {
+rb_objc_ptr_at(VALUE rb_val, long index) {
   struct rb_objc_ptr *dp;
   VALUE val;
   size_t tsize;
@@ -190,7 +223,6 @@ rb_objc_ptr_at(VALUE rb_val, int index) {
 
   if (dp->allocated_size == 0) return Qnil;
   if (dp->encoding == NULL) return Qnil;
-  if (dp->tainted == NO) return Qnil;
 
   tsize = 0;
   NSGetSizeAndAlignment(dp->encoding, &tsize, NULL);
@@ -212,7 +244,7 @@ rb_objc_ptr_at(VALUE rb_val, int index) {
 }
 
 VALUE
-rb_objc_ptr_slice(VALUE rb_val, int index, int length)
+rb_objc_ptr_slice(VALUE rb_val, long index, long length)
 {
   struct rb_objc_ptr *dp;
   VALUE rb_array;
@@ -227,7 +259,6 @@ rb_objc_ptr_slice(VALUE rb_val, int index, int length)
 
   if (dp->allocated_size == 0) return Qnil;
   if (dp->encoding == NULL) return Qnil;
-  if (dp->tainted == NO) return Qnil;
 
   tsize = 0;
   NSGetSizeAndAlignment(dp->encoding, &tsize, NULL);
@@ -263,5 +294,4 @@ rb_objc_ptr_ref(VALUE rb_val, void **data)
   dp = (struct rb_objc_ptr*)DATA_PTR(rb_val);
 
   *(void**)data = &(dp->cptr);
-  dp->tainted = YES;
 }

--- a/ext/obj_ext/RIGSPointer.m
+++ b/ext/obj_ext/RIGSPointer.m
@@ -21,7 +21,6 @@
 
 #import "RIGSPointer.h"
 #import "RIGSCore.h"
-#import "RIGSUtilities.h"
 
 struct rb_objc_ptr
 {

--- a/spec/obj_ruby/pointer_spec.rb
+++ b/spec/obj_ruby/pointer_spec.rb
@@ -26,31 +26,48 @@ RSpec.describe ObjRuby::Pointer do
   end
 
   describe "when accessing a pointer that hasn't been set yet" do
-    it "returns nil" do
-      ptrs = [
-        described_class.new(:object),
-        described_class.new(:bool),
-        described_class.new(:char),
-        described_class.new(:uchar),
-        described_class.new(:short),
-        described_class.new(:ushort),
-        described_class.new(:int),
-        described_class.new(:uint),
-        described_class.new(:long),
-        described_class.new(:ulong),
-        described_class.new(:long_long),
-        described_class.new(:ulong_long),
-        described_class.new(:float),
-        described_class.new(:double)
-      ]
+    it "returns nil for an object" do
+      expect(described_class.new(:object)[0]).to be_nil
+    end
 
-      ptrs.each do |ptr|
-        expect(ptr[0]).to be_nil
-      end
+    it "returns false for a bool" do
+      expect(described_class.new(:bool)[0]).to be false
+    end
+
+    it "returns zero for numerics" do
+      expect(described_class.new(:char)[0]).to eq 0
+      expect(described_class.new(:uchar)[0]).to eq 0
+      expect(described_class.new(:short)[0]).to eq 0
+      expect(described_class.new(:ushort)[0]).to eq 0
+      expect(described_class.new(:int)[0]).to eq 0
+      expect(described_class.new(:uint)[0]).to eq 0
+      expect(described_class.new(:long)[0]).to eq 0
+      expect(described_class.new(:ulong)[0]).to eq 0
+      expect(described_class.new(:long_long)[0]).to eq 0
+      expect(described_class.new(:ulong_long)[0]).to eq 0
+      expect(described_class.new(:float)[0]).to eq 0
+      expect(described_class.new(:double)[0]).to eq 0
     end
   end
 
-  describe "when passing pointer as a param" do
+  describe "when passing a pointer as a param" do
+    it "passes the supplied data as intended" do
+      ptr = described_class.new(:ulong, 3)
+
+      ptr[0] = 8
+      ptr[1] = 9
+      ptr[2] = 10
+
+      index_path = ObjRuby::NSIndexPath.alloc.initWithIndexes_length(ptr, 3)
+
+      expect(index_path.length).to eq 3
+      expect(index_path.indexAtPosition(0)).to eq 8
+      expect(index_path.indexAtPosition(1)).to eq 9
+      expect(index_path.indexAtPosition(2)).to eq 10
+    end
+  end
+
+  describe "when passing pointer as an out param" do
     it "sets NSError data for an object pointer" do
       error_ptr = described_class.new(:object)
 

--- a/spec/obj_ruby/pointer_spec.rb
+++ b/spec/obj_ruby/pointer_spec.rb
@@ -34,8 +34,11 @@ RSpec.describe ObjRuby::Pointer do
       expect(described_class.new(:bool)[0]).to be false
     end
 
+    it "returns zero or false for a char (platform dependent)" do
+      expect(described_class.new(:char)[0]).to eq(0).or be(false)
+    end
+
     it "returns zero for numerics" do
-      expect(described_class.new(:char)[0]).to eq 0
       expect(described_class.new(:uchar)[0]).to eq 0
       expect(described_class.new(:short)[0]).to eq 0
       expect(described_class.new(:ushort)[0]).to eq 0


### PR DESCRIPTION
Some methods in Objective-C take a C array and we have this concept with ObjRuby::Pointer but never got to letting you actually set its values.

Fixes #18