### PR TITLE
Perform loose isa check

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,39 @@ app.activateIgnoringOtherApps(true)
 
 alert = ObjRuby::NSAlert.new
 alert.messageText = "Hello world!"
+
 alert.runModal
+```
+
+Subclasses of `ObjRuby::NSObject` can also be used for delegates such as NSApplicationDelegate.
+
+``` ruby
+require "obj_ruby"
+require "obj_ruby/app_kit"
+
+# NSApplicationDelegate
+class AppDelegate < ObjRuby::NSObject
+  def applicationShouldTerminateAfterLastWindowClosed(_)
+    true
+  end
+end
+
+app = ObjRuby::NSApplication.sharedApplication
+app.activationPolicy = ObjRuby::NSApplicationActivationPolicyRegular
+app.delegate = AppDelegate.new
+
+window = ObjRuby::NSWindow.alloc.initWithContentRect_styleMask_backing_defer(
+  ObjRuby::NSMakeRect(0, 0, 300, 200),
+  ObjRuby::NSTitledWindowMask | ObjRuby::NSWindowStyleMaskClosable,
+  ObjRuby::NSBackingStoreBuffered,
+  false
+)
+window.cascadeTopLeftFromPoint(ObjRuby::NSMakePoint(20, 20))
+window.title = "Hello, from ObjRuby!"
+window.makeKeyAndOrderFront(nil)
+
+app.activateIgnoringOtherApps(true)
+app.run
 ```
 
 For more examples, see this projects [spec](https://github.com/keegnotrub/obj-ruby/tree/main/spec) folder.

--- a/ext/obj_ext/RIGSNSObject.h
+++ b/ext/obj_ext/RIGSNSObject.h
@@ -35,4 +35,6 @@ VALUE rb_objc_object_is_instance_of(VALUE rb_self, VALUE rb_class);
 VALUE rb_objc_object_inherited(VALUE rb_class, VALUE rb_subclass);
 VALUE rb_objc_object_method_added(VALUE rb_class, VALUE rb_method);
 
+BOOL rb_objc_object_isa(void *where);
+
 #endif


### PR DESCRIPTION
Performs a **very** loose isa check on NSObject instances in order to attempt to rule out other pointers.

Also refactors some of our logic this is many places into rb_objc_convert_object_to_ruby

Fixes #22