### PR TITLE
NSDecimal support

### DIFF
--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -833,10 +833,10 @@ rb_objc_type_extend(const char *types, const char *formatString, int nbArgsExtra
   size_t formatStringLength;
   size_t i;
 
-  objcTypesIndex = strlcat(objcTypes, types, strlen(types) + strlen(objcTypes) + 1);
+  objcTypesIndex = strlcpy(objcTypes, types, strlen(types) + strlen(objcTypes) + 1);
   formatStringLength = strlen(formatString);
   i = 0;
-  
+
   while (i < formatStringLength) {
     if (formatString[i++] != '%') continue;
     if (i < formatStringLength && formatString[i] == '%') {
@@ -1063,7 +1063,7 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
 
     rb_objc_type_extend(types, formatString, nbArgsExtra, buf);
     types = buf;
-    nbArgs = (int)rb_objc_type_arity(types);
+    nbArgs += nbArgsExtra;
   }
 
   args = alloca(sizeof(void*) * nbArgs);

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -999,23 +999,23 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
   void **args;
   VALUE rb_arg;
   VALUE rb_retval;
-  ffi_cif cif;
   ffi_type **arg_types;
+  ffi_type *type;
   ffi_type *ret_type;  
+  size_t len;
   size_t ret_len;
+  const char *atypes;
+  const char *rtypes;
+  ffi_cif cif;
   ffi_closure *closure;
   ffi_status status;
   void *closurePtr;
   struct rb_objc_block *block;
   ffi_cif closureCif;
-  ffi_type *type;
-  size_t len;
-  const char *ltypes;
-  const char *rtypes;
   NSInteger formatStringIndex;
   const char *formatString;
-  const char* blockObjcTypes;
-  char buf[256] = { '\0' };    
+  const char *blockObjcTypes;
+  char *buf;
  
   if (rcv != nil) {
     nbArgsAdjust = 2;
@@ -1060,6 +1060,9 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
     else {
       formatString = "";
     }
+
+    buf = alloca(sizeof(char) * 255);
+    memset(buf, '\0', sizeof(char) * 255);
 
     rb_objc_type_extend(types, formatString, nbArgsExtra, buf);
     types = buf;
@@ -1120,10 +1123,10 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
     else {
       type = rb_objc_ffi_type_for_type(types);
       len = 0;
-      ltypes = types;
+      atypes = types;
       types = rb_objc_type_size(types, &len);
       data = alloca(len);
-      rb_objc_convert_to_objc(rigs_argv[i-nbArgsAdjust], &data, 0, ltypes);
+      rb_objc_convert_to_objc(rigs_argv[i-nbArgsAdjust], &data, 0, atypes);
       args[i] = data;
       arg_types[i] = type;
     }

--- a/ext/obj_ext/RIGSCore.m
+++ b/ext/obj_ext/RIGSCore.m
@@ -827,78 +827,6 @@ rb_objc_convert_to_rb(void *data, size_t offset, const char *type, VALUE *rb_val
 }
 
 static void
-rb_objc_type_extend(const char *types, const char *formatString, int nbArgsExtra, char *objcTypes)
-{
-  size_t objcTypesIndex;
-  size_t formatStringLength;
-  size_t i;
-
-  objcTypesIndex = strlcpy(objcTypes, types, strlen(types) + strlen(objcTypes) + 1);
-  formatStringLength = strlen(formatString);
-  i = 0;
-
-  while (i < formatStringLength) {
-    if (formatString[i++] != '%') continue;
-    if (i < formatStringLength && formatString[i] == '%') {
-      i++;
-      continue;
-    }
-    objcTypes[objcTypesIndex] = '\0';
-    while (i < formatStringLength) {
-      switch (formatString[i++]) {
-      case 'd':
-      case 'i':
-      case 'o':
-      case 'u':
-      case 'x':
-      case 'X':
-      case 'c':
-      case 'C':
-        objcTypes[objcTypesIndex] = _C_INT;
-        break;
-      case 'D':
-      case 'O':
-      case 'U':
-        objcTypes[objcTypesIndex] = _C_LNG;
-        break;
-      case 'f':       
-      case 'F':
-      case 'e':       
-      case 'E':
-      case 'g':       
-      case 'G':
-      case 'a':
-      case 'A':
-        objcTypes[objcTypesIndex] = _C_DBL;
-        break;
-      case 's':
-      case 'S':
-        objcTypes[objcTypesIndex] = _C_CHARPTR;
-        break;
-      case 'p':
-        objcTypes[objcTypesIndex] = _C_PTR;
-        break;
-      case '@':
-        objcTypes[objcTypesIndex] = _C_ID;
-        break;            
-      }
-      if (objcTypes[objcTypesIndex] != '\0') {
-        objcTypesIndex++;
-        if (--nbArgsExtra < 0) {
-          rb_raise(rb_eArgError, "too many tokens in the format string '%s' for the given argument(s)", formatString);
-        }
-        break;
-      }
-    }
-  }
-
-  while (nbArgsExtra-- > 0) {
-    objcTypes[objcTypesIndex++] = _C_ID;
-  }
-  objcTypes[objcTypesIndex] = '\0';
-}
-
-static void
 rb_objc_proxy_handler(ffi_cif *cif, void *ret, void **args, void *user_data) {
   @autoreleasepool {
     SEL sel;
@@ -1016,6 +944,7 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
   const char *formatString;
   const char *blockObjcTypes;
   char *buf;
+  char keyChar;
  
   if (rcv != nil) {
     nbArgsAdjust = 2;
@@ -1063,10 +992,21 @@ rb_objc_dispatch(id rcv, const char *method, unsigned long hash, const char *typ
 
     buf = alloca(sizeof(char) * 255);
     memset(buf, '\0', sizeof(char) * 255);
+    len = strlcpy(buf, types, strlen(types) + strlen(buf) + 1);    
 
-    rb_objc_type_extend(types, formatString, nbArgsExtra, buf);
+    i = nbArgsExtra;
+    while (len < 255 && (formatString = rb_objc_format_keychar(formatString, &keyChar))) {
+      buf[len++] = keyChar;
+      nbArgs++;
+      if (--i < 0) {
+        rb_raise(rb_eArgError, "too many tokens in the format string for the given argument(s)");
+      }
+    }
+    while (len < 255 && i-- > 0) {
+      buf[len++] = _C_ID;
+      nbArgs++;
+    }
     types = buf;
-    nbArgs += nbArgsExtra;
   }
 
   args = alloca(sizeof(void*) * nbArgs);

--- a/ext/obj_ext/RIGSUtilities.h
+++ b/ext/obj_ext/RIGSUtilities.h
@@ -44,10 +44,12 @@ unsigned long rb_objc_hash(const char *value);
 unsigned long rb_objc_hash_s(const char *value, unsigned long seed);
 unsigned long rb_objc_hash_struct(const char *value);
 unsigned long rb_objc_struct_type_arity(const char *type);
+unsigned long rb_objc_type_arity(const char *type);
 const char *rb_objc_skip_type_qualifiers(const char *type);
 const char *rb_objc_skip_type_size(const char *type);
 const char *rb_objc_skip_type_sname(const char *type);
 const char *rb_objc_skip_type_uname(const char *type);
 const char *rb_objc_skip_typespec(const char *type);
+const char *rb_objc_type_size(const char *type, size_t *size);
 
 #endif /* __RIGSUtilitis_h_GNUSTEP_RUBY_INCLUDE */

--- a/ext/obj_ext/RIGSUtilities.h
+++ b/ext/obj_ext/RIGSUtilities.h
@@ -51,5 +51,6 @@ const char *rb_objc_skip_type_sname(const char *type);
 const char *rb_objc_skip_type_uname(const char *type);
 const char *rb_objc_skip_typespec(const char *type);
 const char *rb_objc_type_size(const char *type, size_t *size);
+const char *rb_objc_format_keychar(const char *format, char *keyChar);
 
 #endif /* __RIGSUtilitis_h_GNUSTEP_RUBY_INCLUDE */

--- a/ext/obj_ext/RIGSUtilities.m
+++ b/ext/obj_ext/RIGSUtilities.m
@@ -469,43 +469,49 @@ rb_objc_format_keychar(const char *format, char *keyChar)
   char fmtChar;
 
   while ((fmtChar = *format++)) {
-    if (fmtChar != '%') continue;    
-    switch(*format) {
-    case 'd':
-    case 'i':
-    case 'o':
-    case 'u':
-    case 'x':
-    case 'X':
-    case 'c':
-    case 'C':
-      *keyChar = _C_INT;
-      return format + 1;
-    case 'D':
-    case 'O':
-    case 'U':
-      *keyChar = _C_LNG;
-      return format + 1;
-    case 'f':       
-    case 'F':
-    case 'e':       
-    case 'E':
-    case 'g':       
-    case 'G':
-    case 'a':
-    case 'A':
-      *keyChar = _C_DBL;
-      return format + 1;
-    case 's':
-    case 'S':
-      *keyChar = _C_CHARPTR;
-      return format + 1;
-    case 'p':
-      *keyChar = _C_PTR;
-      return format + 1;
-    case '@':
-      *keyChar = _C_ID;
-      return format + 1;
+    if (fmtChar != '%') continue;
+    if (*format == '%') {
+      format++;
+      continue;
+    }
+    while ((fmtChar = *format++)) {
+      switch(fmtChar) {
+      case 'd':
+      case 'i':
+      case 'o':
+      case 'u':
+      case 'x':
+      case 'X':
+      case 'c':
+      case 'C':
+        *keyChar = _C_INT;
+        return format;
+      case 'D':
+      case 'O':
+      case 'U':
+        *keyChar = _C_LNG;
+        return format;
+      case 'f':
+      case 'F':
+      case 'e':
+      case 'E':
+      case 'g':
+      case 'G':
+      case 'a':
+      case 'A':
+        *keyChar = _C_DBL;
+        return format;
+      case 's':
+      case 'S':
+        *keyChar = _C_CHARPTR;
+        return format;
+      case 'p':
+        *keyChar = _C_PTR;
+        return format;
+      case '@':
+        *keyChar = _C_ID;
+        return format;
+      }
     }
   }
 

--- a/ext/obj_ext/RIGSUtilities.m
+++ b/ext/obj_ext/RIGSUtilities.m
@@ -462,3 +462,52 @@ rb_objc_skip_typespec(const char *type)
     return 0;
   }
 }
+
+const char *
+rb_objc_format_keychar(const char *format, char *keyChar)
+{
+  char fmtChar;
+
+  while ((fmtChar = *format++)) {
+    if (fmtChar != '%') continue;    
+    switch(*format) {
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X':
+    case 'c':
+    case 'C':
+      *keyChar = _C_INT;
+      return format + 1;
+    case 'D':
+    case 'O':
+    case 'U':
+      *keyChar = _C_LNG;
+      return format + 1;
+    case 'f':       
+    case 'F':
+    case 'e':       
+    case 'E':
+    case 'g':       
+    case 'G':
+    case 'a':
+    case 'A':
+      *keyChar = _C_DBL;
+      return format + 1;
+    case 's':
+    case 'S':
+      *keyChar = _C_CHARPTR;
+      return format + 1;
+    case 'p':
+      *keyChar = _C_PTR;
+      return format + 1;
+    case '@':
+      *keyChar = _C_ID;
+      return format + 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This is a bit crazy, NSDecimal uses a few things we never supported (bitfields and array), and NSMethodSignature does not support bitfields. So this will require a lot of changes to make work, but curious if performance improves (`bin/benchmark`)